### PR TITLE
Improve doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,10 @@ all:
 }
 ```
 
+> **Note**: <br />
+> to have a fully functional deployment make sure to use either an **external IP** or an **internal IP** for `rabbitmq_host` based on the infra network configuration. <br />
+> Additionally, retrieving the actual api-key from the server is not supported yet, so use `"enable_api_key": "false"` in extra vars as any value in `trento_api_key` would be ineffective.
+
 Both trento-server and agent inventory and variables file can be combined to deploy both at the same ansible execution.
 
 Having an inventory file called `inventory.yml` and a vars file called `extra-vars.json`, you could run the playbook

--- a/roles/containers/tasks/main.yml
+++ b/roles/containers/tasks/main.yml
@@ -18,6 +18,7 @@
    networks:
     - name: trentonet
    image: "ghcr.io/trento-project/trento-wanda:rolling"
+   pull: true
    entrypoint: ["/bin/sh", "-c", "/app/bin/wanda eval \"Wanda.Release.init()\" && /app/bin/wanda start"]
    etc_hosts:
     host.docker.internal: "host-gateway"
@@ -36,6 +37,7 @@
    state: started
    restart_policy: unless-stopped
    image: "ghcr.io/trento-project/trento-web:rolling"
+   pull: true
    networks:
     - name: trentonet
    entrypoint: ["/bin/sh", "-c", "/app/bin/trento eval \"Trento.Release.init()\" && /app/bin/trento start"]

--- a/roles/proxy/templates/trento.conf.j2
+++ b/roles/proxy/templates/trento.conf.j2
@@ -21,7 +21,7 @@ server {
   listen 80;
 
   location {{ grafana_sub_path }}/ {
-    rewrite  ^/{{ grafana_sub_path }}/(.*)  /$1 break;
+    rewrite  ^{{ grafana_sub_path }}/(.*)  /$1 break;
     proxy_set_header Host $http_host;
     proxy_pass http://grafana;
   }


### PR DESCRIPTION
Some minor improvements that might help:
- note about using proper IP for rabbitmq based on network congif
- note about api-key not being supported yet, so better disable it to get a functional deployment
- always pull images to get the latest version among playbook reruns
- minor fix in nginx config template to avoid double slashes `//grafana`