### PR TITLE
Cleanup rabbitmq

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ These variables are the defaults of our roles, if you want to override the prope
 | wanda_postgres_db | Name of the postgres database of wanda application | wanda |
 | web_postgres_host | Postgres host of web project container | host.docker.internal |
 | wanda_postgres_host | Postgres host of wanda project container | host.docker.internal |
+| rabbitmq_vhost | The rabbitmq vhost used for the current deployment. Don't add trailling slashes to the value such as `/myvhost` | trento |
 | rabbitmq_username | Username of rabbitmq user, this will be created by the rabbitmq role | trento |
 | rabbitmq_node_name | The name of rabbitmq node | rabbit@localhost | host.docker.internal |
 | rabbitmq_host | The rabbitmq host, used by web and wanda containers. It could include the service port |
@@ -292,6 +293,7 @@ These are the cleaned resources:
 - Docker network
 - Postgresql database and users
 - Nginx vhost configuration file
+- RabbitMQ vhost
 
 Run the playbook with:
 

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ These variables are the defaults of our roles, if you want to override the prope
 | wanda_postgres_db | Name of the postgres database of wanda application | wanda |
 | web_postgres_host | Postgres host of web project container | host.docker.internal |
 | wanda_postgres_host | Postgres host of wanda project container | host.docker.internal |
-| rabbitmq_vhost | The rabbitmq vhost used for the current deployment. Don't add trailling slashes to the value such as `/myvhost` | trento |
+| rabbitmq_vhost | The rabbitmq vhost used for the current deployment | trento |
 | rabbitmq_username | Username of rabbitmq user, this will be created by the rabbitmq role | trento |
 | rabbitmq_node_name | The name of rabbitmq node | rabbit@localhost | host.docker.internal |
 | rabbitmq_host | The rabbitmq host, used by web and wanda containers. It could include the service port |

--- a/playbook.cleanup.yml
+++ b/playbook.cleanup.yml
@@ -21,3 +21,12 @@
      ansible.builtin.include_role:
       name: postgres
       tasks_from: cleanup
+
+- name: Clean up rabbitmq
+  hosts: rabbitmq-hosts
+  become: true
+  tasks:
+   - name: Rabbitmq
+     ansible.builtin.include_role:
+      name: rabbitmq
+      tasks_from: cleanup

--- a/roles/containers/defaults/main.yml
+++ b/roles/containers/defaults/main.yml
@@ -15,6 +15,7 @@ wanda_postgres_user: wanda
 wanda_postgres_db: wandadb
 rabbitmq_username: trento
 rabbitmq_host: host.docker.internal
+rabbitmq_vhost: "trento"
 grafana_public_url: "/grafana"
 grafana_api_url: "http://host.docker.internal:3000/api"
 secret_key_base: "lookup('community.general.random_string', base64=True, length=64)"

--- a/roles/containers/tasks/main.yml
+++ b/roles/containers/tasks/main.yml
@@ -28,7 +28,7 @@
     CORS_ORIGIN: "http://localhost" # TODO: Remove placeholder
     SECRET_KEY_BASE: "{{ secret_key_base }}"
     ACCESS_TOKEN_ENC_SECRET: "{{ access_token_secret }}"
-    AMQP_URL: "{{ amqp_protocol }}://{{ rabbitmq_username }}:{{ rabbitmq_password }}@{{ rabbitmq_host }}"
+    AMQP_URL: "{{ amqp_protocol }}://{{ rabbitmq_username }}:{{ rabbitmq_password }}@{{ rabbitmq_host }}/{{ rabbitmq_vhost }}"
     DATABASE_URL: "ecto://{{ wanda_postgres_user }}:{{ wanda_postgres_password }}@{{ wanda_postgres_host }}/{{ wanda_postgres_db }}"
 
 - name: Web container
@@ -46,7 +46,7 @@
    ports:
     - "{{ web_container_port }}:4000"
    env:
-    AMQP_URL: "{{ amqp_protocol }}://{{ rabbitmq_username }}:{{ rabbitmq_password }}@{{ rabbitmq_host }}"
+    AMQP_URL: "{{ amqp_protocol }}://{{ rabbitmq_username }}:{{ rabbitmq_password }}@{{ rabbitmq_host }}/{{ rabbitmq_vhost }}"
     DATABASE_URL: "ecto://{{ web_postgres_user }}:{{ web_postgres_password }}@{{ web_postgres_host }}/{{ web_postgres_db }}"
     EVENTSTORE_URL: "ecto://{{ web_postgres_user }}:{{ web_postgres_password }}@{{ web_postgres_host }}/{{ web_postgres_event_store }}"
     ENABLE_ALERTING: "{{ enable_alerting }}"

--- a/roles/containers/tasks/main.yml
+++ b/roles/containers/tasks/main.yml
@@ -28,7 +28,7 @@
     CORS_ORIGIN: "http://localhost" # TODO: Remove placeholder
     SECRET_KEY_BASE: "{{ secret_key_base }}"
     ACCESS_TOKEN_ENC_SECRET: "{{ access_token_secret }}"
-    AMQP_URL: "{{ amqp_protocol }}://{{ rabbitmq_username }}:{{ rabbitmq_password }}@{{ rabbitmq_host }}/{{ rabbitmq_vhost }}"
+    AMQP_URL: "{{ amqp_protocol }}://{{ rabbitmq_username }}:{{ rabbitmq_password }}@{{ rabbitmq_host }}/{{ rabbitmq_vhost | urlencode | replace('/', '%2F') }}"
     DATABASE_URL: "ecto://{{ wanda_postgres_user }}:{{ wanda_postgres_password }}@{{ wanda_postgres_host }}/{{ wanda_postgres_db }}"
 
 - name: Web container
@@ -46,7 +46,7 @@
    ports:
     - "{{ web_container_port }}:4000"
    env:
-    AMQP_URL: "{{ amqp_protocol }}://{{ rabbitmq_username }}:{{ rabbitmq_password }}@{{ rabbitmq_host }}/{{ rabbitmq_vhost }}"
+    AMQP_URL: "{{ amqp_protocol }}://{{ rabbitmq_username }}:{{ rabbitmq_password }}@{{ rabbitmq_host }}/{{ rabbitmq_vhost | urlencode | replace('/', '%2F') }}"
     DATABASE_URL: "ecto://{{ web_postgres_user }}:{{ web_postgres_password }}@{{ web_postgres_host }}/{{ web_postgres_db }}"
     EVENTSTORE_URL: "ecto://{{ web_postgres_user }}:{{ web_postgres_password }}@{{ web_postgres_host }}/{{ web_postgres_event_store }}"
     ENABLE_ALERTING: "{{ enable_alerting }}"

--- a/roles/rabbitmq/defaults/main.yml
+++ b/roles/rabbitmq/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 rabbitmq_username: trento
 rabbitmq_node_name: "rabbit@localhost"
+rabbitmq_vhost: "trento"

--- a/roles/rabbitmq/tasks/cleanup.yml
+++ b/roles/rabbitmq/tasks/cleanup.yml
@@ -1,0 +1,13 @@
+# code: language=ansible
+---
+- name: Remove rabbitmq trento user
+  community.rabbitmq.rabbitmq_user:
+    user: "{{ rabbitmq_username }}"
+    node: "{{ rabbitmq_node_name }}"
+    state: absent
+
+- name: Remove rabbitmq trento vhost
+  community.rabbitmq.rabbitmq_vhost:
+    name: "{{ rabbitmq_vhost }}"
+    node: "{{ rabbitmq_node_name }}"
+    state: absent

--- a/roles/rabbitmq/tasks/main.yml
+++ b/roles/rabbitmq/tasks/main.yml
@@ -18,13 +18,19 @@
    state: started
    enabled: true
 
+- name: Create rabbitmq trento vhost
+  community.rabbitmq.rabbitmq_vhost:
+   name: "{{ rabbitmq_vhost }}"
+   node: "{{ rabbitmq_node_name }}"
+   state: present
+
 - name: Configure rabbitmq trento user
   community.rabbitmq.rabbitmq_user:
    user: "{{ rabbitmq_username }}"
    node: "{{ rabbitmq_node_name }}"
    password: "{{ rabbitmq_password }}"
    permissions:
-    - vhost: "/"
+    - vhost: "{{ rabbitmq_vhost }}"
       configure_priv: ".*"
       read_priv: ".*"
       write_priv: ".*"


### PR DESCRIPTION
Clean up rabbitmq vhost (which now is configurable). Once the vhost is cleaned up all the exchanges/queues are gone.
Using vhosts enables us to have completely independent environments using the same exchange names: https://www.rabbitmq.com/vhosts.html

The amqp connection string vhost part must be encoded (urlencode doesn't replace `/`... https://jinja.palletsprojects.com/en/2.11.x/templates/#urlencode).
Anyway, we should maybe encourage the creation of vhosts without trailling `/`...