### PR TITLE
Remove container images optionally during cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,8 +250,10 @@ These variables are the defaults of our roles, if you want to override the prope
 | wanda_container_name | Name of the Wanda container | trento_wanda |
 | wanda_container_port | Port where the Wanda container is exposed | 4001 |
 | force_pull_images | Force pull the container images for trento components | false |
-| force_recreate_wanda_container | Recreate the wanda container | false |
 | force_recreate_web_container | Recreate the web container | false |
+| force_recreate_wanda_container | Recreate the wanda container | false |
+| remove_web_container_image | Remove Web container image in cleanup task | true |
+| remove_wanda_container_image | Remove Wanda container image in cleanup task | true |
 | web_postgres_db | Name of the postgres database of the web application | webdb |
 | web_postgres_event_store | Name of the postgres event store database of web application | event_store |
 | web_postgres_user | Name of the postgres user used by web application | web |

--- a/roles/containers/defaults/main.yml
+++ b/roles/containers/defaults/main.yml
@@ -10,6 +10,8 @@ web_postgres_host: "host.docker.internal"
 force_pull_images: "false"
 force_recreate_wanda_container: "false"
 force_recreate_web_container: "false"
+remove_web_container_image: "true"
+remove_wanda_container_image: "true"
 wanda_container_image: ghcr.io/trento-project/trento-wanda:rolling
 wanda_container_name: trento_wanda
 wanda_container_port: "{{ 32767 | random(start=1024, seed=trento_server_name) + 1 }}"

--- a/roles/containers/tasks/cleanup.yml
+++ b/roles/containers/tasks/cleanup.yml
@@ -13,11 +13,13 @@
     keep_volumes: false
 
 - name: Remove wanda container image
+  when: remove_wanda_container_image == 'true'
   community.docker.docker_image:
     state: absent
     name: "{{ wanda_container_image }}"
 
 - name: Remove web container image
+  when: remove_web_container_image == 'true'
   community.docker.docker_image:
     state: absent
     name: "{{ web_container_image }}"


### PR DESCRIPTION
Remove web and wanda container images optionally, removing them being the default behaviour.
This enables the cleanup usage in the PR environment creation, as we don't want to remove wanda image as it uses a fixed tag