### PR TITLE
Add distribution detection logic

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -4,87 +4,87 @@
   hosts: trento-server
   become: true
   pre_tasks:
-    - name: Check SLES distribution and version
-      ansible.builtin.fail:
-        msg: "This playbook only runs on SLES for SAP 15 SP3 or above. Detected: {{ ansible_distribution }} {{ ansible_distribution_version }}"
-      when: >
-        ((ansible_distribution != "SLES_SAP") and
-        (ansible_distribution != "openSUSE Leap")) or
-        (ansible_distribution_version is version('15.3', '<'))
+   - name: Check SLES distribution and version
+     ansible.builtin.fail:
+      msg: "This playbook only runs on SLES for SAP 15 SP3 or above. Detected: {{ ansible_distribution }} {{ ansible_distribution_version }}"
+     when: >
+      ((ansible_distribution != "SLES_SAP") and
+      (ansible_distribution != "openSUSE Leap")) or
+      (ansible_distribution_version is version('15.3', '<'))
 
   tasks:
-    - name: Install installation prerequisites
-      community.general.zypper:
-        name:
-          - gcc
-          - python3-devel
-          - sudo
+   - name: Install installation prerequisites
+     community.general.zypper:
+      name:
+       - gcc
+       - python3-devel
+       - sudo
 
-    - name: Install python prerequisites
-      community.general.zypper:
-        name:
-          - python3-setuptools
-          - python3-pip
-          - python3-pexpect
-        state: present
-        update_cache: true
+   - name: Install python prerequisites
+     community.general.zypper:
+      name:
+       - python3-setuptools
+       - python3-pip
+       - python3-pexpect
+      state: present
+      update_cache: true
 
-    - name: Install docker
-      community.general.zypper:
-        name: docker
-        state: present
-        update_cache: true
+   - name: Install docker
+     community.general.zypper:
+      name: docker
+      state: present
+      update_cache: true
 
-    - name: Start docker service
-      ansible.builtin.service:
-        name: docker
-        state: started
-        enabled: true
+   - name: Start docker service
+     ansible.builtin.service:
+      name: docker
+      state: started
+      enabled: true
 
 - name: Provision postgres
   become: true
   vars:
-    provision_postgres: "true"
+   provision_postgres: "true"
   hosts: postgres-hosts
   roles:
-    - role: postgres
-      when: provision_postgres == 'true'
-      become: true
+   - role: postgres
+     when: provision_postgres == 'true'
+     become: true
 
 - name: Provision prometheus
   become: true
   vars:
-    provision_prometheus: "true"
+   provision_prometheus: "true"
   hosts: prometheus-hosts
   roles:
-    - role: prometheus
-      when: provision_prometheus == 'true'
-      become: true
+   - role: prometheus
+     when: provision_prometheus == 'true'
+     become: true
 
 - name: Provision rabbitmq
   become: true
   vars:
-    provision_rabbitmq: "true"
+   provision_rabbitmq: "true"
   hosts: rabbitmq-hosts
   roles:
-    - role: rabbitmq
-      when: provision_rabbitmq == 'true'
+   - role: rabbitmq
+     when: provision_rabbitmq == 'true'
 
 - name: Configure trento projects
   vars:
-    provision_proxy: "true"
+   provision_proxy: "true"
   hosts: trento-server
   become: true
   roles:
-    - role: containers
-      become: true
-    - role: proxy
-      when: provision_proxy == 'true'
-      become: true
+   - role: containers
+     become: true
+   - role: proxy
+     when: provision_proxy == 'true'
+     become: true
 
 - name: Configure trento agents
   hosts: agents
   become: true
   roles:
-    - role: agent
-      become: true
+   - role: agent
+     become: true

--- a/playbook.yml
+++ b/playbook.yml
@@ -5,7 +5,7 @@
   become: true
   pre_tasks:
     - name: Check SLES distribution and version
-      fail:
+      ansible.builtin.fail:
         msg: "This playbook only runs on SLES for SAP 15 SP3 or above. Detected: {{ ansible_distribution }} {{ ansible_distribution_version }}"
       when: >
         (ansible_distribution != "SLES_SAP") or

--- a/playbook.yml
+++ b/playbook.yml
@@ -8,7 +8,8 @@
       ansible.builtin.fail:
         msg: "This playbook only runs on SLES for SAP 15 SP3 or above. Detected: {{ ansible_distribution }} {{ ansible_distribution_version }}"
       when: >
-        (ansible_distribution != "SLES_SAP") or
+        ((ansible_distribution != "SLES_SAP") and
+        (ansible_distribution != "openSUSE Leap")) or
         (ansible_distribution_version is version('15.3', '<'))
 
   tasks:

--- a/playbook.yml
+++ b/playbook.yml
@@ -4,78 +4,78 @@
   hosts: trento-server
   become: true
   tasks:
-   - name: Install installation prerequisites
-     community.general.zypper:
-      name:
-       - gcc
-       - python3-devel
-       - sudo
+    - name: Install installation prerequisites
+      community.general.zypper:
+        name:
+          - gcc
+          - python3-devel
+          - sudo
 
-   - name: Install python prerequisites
-     community.general.zypper:
-      name:
-       - python3-setuptools
-       - python3-pip
-       - python3-pexpect
-      state: present
-      update_cache: true
+    - name: Install python prerequisites
+      community.general.zypper:
+        name:
+          - python3-setuptools
+          - python3-pip
+          - python3-pexpect
+        state: present
+        update_cache: true
 
-   - name: Install docker
-     community.general.zypper:
-      name: docker
-      state: present
-      update_cache: true
+    - name: Install docker
+      community.general.zypper:
+        name: docker
+        state: present
+        update_cache: true
 
-   - name: Start docker service
-     ansible.builtin.service:
-      name: docker
-      state: started
-      enabled: true
+    - name: Start docker service
+      ansible.builtin.service:
+        name: docker
+        state: started
+        enabled: true
 
 - name: Provision postgres
   become: true
   vars:
-   provision_postgres: "true"
+    provision_postgres: "true"
   hosts: postgres-hosts
   roles:
-   - role: postgres
-     when: provision_postgres == 'true'
-     become: true
+    - role: postgres
+      when: provision_postgres == 'true'
+      become: true
 
 - name: Provision prometheus
   become: true
   vars:
-   provision_prometheus: "true"
+    provision_prometheus: "true"
   hosts: prometheus-hosts
   roles:
-   - role: prometheus
-     when: provision_prometheus == 'true'
-     become: true
+    - role: prometheus
+      when: provision_prometheus == 'true'
+      become: true
 
 - name: Provision rabbitmq
   become: true
   vars:
-   provision_rabbitmq: "true"
+    provision_rabbitmq: "true"
   hosts: rabbitmq-hosts
   roles:
-   - role: rabbitmq
-     when: provision_rabbitmq == 'true'
+    - role: rabbitmq
+      when: provision_rabbitmq == 'true'
 
 - name: Configure trento projects
   vars:
-   provision_proxy: "true"
+    provision_proxy: "true"
   hosts: trento-server
   become: true
   roles:
-   - role: containers
-     become: true
-   - role: proxy
-     when: provision_proxy == 'true'
-     become: true
+    - role: containers
+      become: true
+    - role: proxy
+      when: provision_proxy == 'true'
+      become: true
 
 - name: Configure trento agents
   hosts: agents
   become: true
   roles:
-   - role: agent
-     become: true
+    - role: agent
+      become: true

--- a/playbook.yml
+++ b/playbook.yml
@@ -3,6 +3,14 @@
 - name: Install thirdparties
   hosts: trento-server
   become: true
+  pre_tasks:
+    - name: Check SLES distribution and version
+      fail:
+        msg: "This playbook only runs on SLES for SAP 15 SP3 or above. Detected: {{ ansible_distribution }} {{ ansible_distribution_version }}"
+      when: >
+        (ansible_distribution != "SLES_SAP") or
+        (ansible_distribution_version is version('15.3', '<'))
+
   tasks:
     - name: Install installation prerequisites
       community.general.zypper:

--- a/roles/prometheus/tasks/main.yml
+++ b/roles/prometheus/tasks/main.yml
@@ -1,9 +1,5 @@
 # code: language=ansible
 ---
-- name: Gather the version of SLES_SAP
-  ansible.builtin.setup:
-    filter: ansible_distribution_version
-
 - name: Ensure prometheus group is present
   ansible.builtin.group:
     name: prometheus

--- a/roles/prometheus/tasks/main.yml
+++ b/roles/prometheus/tasks/main.yml
@@ -1,9 +1,14 @@
 # code: language=ansible
 ---
+- name: Gather the version of SLES_SAP
+  ansible.builtin.setup:
+    filter: ansible_distribution_version
+
 - name: Ensure prometheus group is present
   ansible.builtin.group:
     name: prometheus
     system: true
+  when: ansible_distribution_version >= "15.4"
 
 - name: Create Prometheus system user
   ansible.builtin.user:
@@ -12,6 +17,7 @@
     group: prometheus
     shell: /sbin/nologin
     comment: "User for Prometheus service"
+  when: ansible_distribution_version >= "15.4"
 
 - name: Install package using expect
   ansible.builtin.expect:
@@ -19,6 +25,13 @@
     responses:
       (?i)Choose from above solutions by number or cancel: "2"
       (?i)Continue?: "y"
+  when: ansible_distribution_version >= "15.4"
+
+- name: Install Prometheus package using zypper
+  ansible.builtin.package:
+    name: golang-github-prometheus-prometheus
+    state: present
+  when: ansible_distribution_version is version('15.4', '<')
 
 - name: Enable prometheus service
   ansible.builtin.service:

--- a/roles/prometheus/tasks/main.yml
+++ b/roles/prometheus/tasks/main.yml
@@ -15,7 +15,7 @@
     comment: "User for Prometheus service"
   when: ansible_distribution_version >= "15.4"
 
-- name: Install package using expect
+- name: Install package manually using expect module
   ansible.builtin.expect:
     command: zypper install golang-github-prometheus-prometheus
     responses:
@@ -23,7 +23,7 @@
       (?i)Continue?: "y"
   when: ansible_distribution_version >= "15.4"
 
-- name: Install Prometheus package using zypper
+- name: Install package using zypper module
   ansible.builtin.package:
     name: golang-github-prometheus-prometheus
     state: present


### PR DESCRIPTION
This PR adds:
 - A check in the pre_tasks of the playbook. The check will prevent the execution on distributions others than SLES for SAP 15 SP3, SP4 or SP5
 - A conditional that executes the `expect` workaround that manually installs the user/group for prometheus. This conditional will ensure that the workaround is only executed when needed (SP4 and SP5)
 - Changes yaml formatting for the playbook so that we use 2 spaces for indentation. I've seen this in most of YAML guidelines and my formatter follows this also. I can remove it if we prefer to stay with 1-space.
 
 I've checked the logic in all 3 supported targets and it works as expected