### PR TITLE
Allow charts to be optional when deploying trento-web

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ These variables are the defaults of our roles, if you want to override the prope
 | nginx_vhost_http_listen_port | Configure the http listen port for trento (redirects to https by default) | 80 |
 | nginx_vhost_https_listen_port | Configure the https listen port for trento | 443 |
 | enable_api_key | Enable/Disable API key usage. Mostly for testing purposes | true |
+| enable_charts | Enable/Disable charts display based on Prometheus metrics | true |
 | web_upstream_name | Web nginx upstream name | web |
 | wanda_upstream_name | Wanda nginx upstream name | wanda |
 | amqp_protocol | Change the amqp protocol type | amqp |

--- a/roles/containers/defaults/main.yml
+++ b/roles/containers/defaults/main.yml
@@ -27,5 +27,6 @@ refresh_token_secret: "lookup('community.general.random_string', base64=True, le
 web_admin_username: admin
 enable_alerting: "false"
 enable_api_key: "true"
+enable_charts: "true"
 amqp_protocol: amqp
 prometheus_url: "http://host.docker.internal:9090"

--- a/roles/containers/tasks/main.yml
+++ b/roles/containers/tasks/main.yml
@@ -85,4 +85,4 @@
       ADMIN_USER: "{{ web_admin_username }}"
       ADMIN_PASSWORD: "{{ web_admin_password }}"
       ENABLE_API_KEY: "{{ enable_api_key }}"
-      ENABLE_CHARTS: "{{ enable_charts }}"
+      CHARTS_ENABLED: "{{ enable_charts }}"

--- a/roles/containers/tasks/main.yml
+++ b/roles/containers/tasks/main.yml
@@ -85,3 +85,4 @@
       ADMIN_USER: "{{ web_admin_username }}"
       ADMIN_PASSWORD: "{{ web_admin_password }}"
       ENABLE_API_KEY: "{{ enable_api_key }}"
+      ENABLE_CHARTS: "{{ enable_charts }}"


### PR DESCRIPTION
This PR makes use of the env var added in https://github.com/trento-project/web/pull/2147 to disable the usage of the new charts feature by introducing the `enable_charts` var. The variable has a default value of `true` (it shouldn't be necessary to set it true as it's already `true` by default in `trento-web` but I think it helps to make it more obvious)

@CDimonaco something I noticed is that you used `CHARTS_ENABLED` for the env var, where we usually use the form `ENABLE_<something>` for such things, if it's ok by you, could we change this for uniformity?