### PR TITLE
Only apply firewalld exceptions when firewalld is running

### DIFF
--- a/playbook.cleanup.yml
+++ b/playbook.cleanup.yml
@@ -1,5 +1,19 @@
 # code: language=ansible
 ---
+- name: Check firewalld package on prometheus and trento-server hosts
+  hosts: prometheus-hosts:trento-server
+  tasks:
+    - name: Collect package facts
+      ansible.builtin.package_facts:
+        manager: auto
+    - name: Check if a specific package is installed
+      ansible.builtin.set_fact:
+        firewalld_installed: "{{ 'firewalld' in ansible_facts.packages }}"
+    - name: Check the status of firewalld
+      ansible.builtin.systemd:
+        name: firewalld.service
+      register: firewalld_status
+
 - name: Clean up trento projects
   hosts: trento-server
   become: true
@@ -29,4 +43,13 @@
     - name: Rabbitmq
       ansible.builtin.include_role:
         name: rabbitmq
+        tasks_from: cleanup
+
+- name: Prometheus cleanup
+  hosts: prometheus-hosts
+  become: true
+  tasks:
+    - name: Prometheus
+      ansible.builtin.include_role:
+        name: prometheus
         tasks_from: cleanup

--- a/playbook.yml
+++ b/playbook.yml
@@ -41,6 +41,22 @@
         state: started
         enabled: true
 
+- name: Check firewalld package on prometheus and trento-server hosts
+  hosts: prometheus-hosts:trento-server
+  tasks:
+    - name: Collect package facts
+      ansible.builtin.package_facts:
+        manager: auto
+
+    - name: Check if a specific package is installed
+      ansible.builtin.set_fact:
+        firewalld_installed: "{{ 'firewalld' in ansible_facts.packages }}"
+
+    - name: Check the status of firewalld
+      ansible.builtin.systemd:
+        name: firewalld.service
+      register: firewalld_status
+
 - name: Provision postgres
   become: true
   vars:

--- a/playbook.yml
+++ b/playbook.yml
@@ -52,6 +52,8 @@
       ansible.builtin.set_fact:
         firewalld_installed: "{{ 'firewalld' in ansible_facts.packages }}"
 
+    # This task is required because immediate: true does not work with offline
+    # This should be fixed in newer ansible versions and could be removed in the future
     - name: Check the status of firewalld
       ansible.builtin.systemd:
         name: firewalld.service

--- a/roles/prometheus/handlers/main.yml
+++ b/roles/prometheus/handlers/main.yml
@@ -1,10 +1,5 @@
 # code: language=ansible
 ---
-- name: Restart nginx
-  ansible.builtin.service:
-    name: nginx
-    state: restarted
-
 - name: Restart firewalld if running
   ansible.builtin.service:
     name: firewalld

--- a/roles/prometheus/tasks/cleanup.yml
+++ b/roles/prometheus/tasks/cleanup.yml
@@ -1,15 +1,11 @@
 # code: language=ansible
 ---
-- name: Check the status of firewalld
-  ansible.builtin.systemd:
-    name: firewalld.service
-  register: firewalld_status
-
 - name: Close prometheus port using firewalld
   ansible.posix.firewalld:
     port: "{{ prometheus_port }}/tcp"
     permanent: true
     state: disabled
-    immediate: true
     offline: true
-  when: firewalld_status.status.ActiveState == "active"
+  when: firewalld_installed
+  notify:
+    - Restart firewalld if running

--- a/roles/prometheus/tasks/cleanup.yml
+++ b/roles/prometheus/tasks/cleanup.yml
@@ -1,8 +1,15 @@
 # code: language=ansible
 ---
+- name: Check the status of firewalld
+  ansible.builtin.systemd:
+    name: firewalld.service
+  register: firewalld_status
+
 - name: Close prometheus port using firewalld
   ansible.posix.firewalld:
     port: "{{ prometheus_port }}/tcp"
     permanent: true
     state: disabled
     immediate: true
+    offline: true
+  when: firewalld_status.status.ActiveState == "active"

--- a/roles/prometheus/tasks/main.yml
+++ b/roles/prometheus/tasks/main.yml
@@ -35,9 +35,16 @@
     state: started
     enabled: true
 
+- name: Check the status of firewalld
+  ansible.builtin.systemd:
+    name: firewalld.service
+  register: firewalld_status
+
 - name: Open prometheus port using firewalld
   ansible.posix.firewalld:
     port: "{{ prometheus_port }}/tcp"
     permanent: true
     state: enabled
     immediate: true
+    offline: true
+  when: firewalld_status.status.ActiveState == "active"

--- a/roles/prometheus/tasks/main.yml
+++ b/roles/prometheus/tasks/main.yml
@@ -35,16 +35,12 @@
     state: started
     enabled: true
 
-- name: Check the status of firewalld
-  ansible.builtin.systemd:
-    name: firewalld.service
-  register: firewalld_status
-
 - name: Open prometheus port using firewalld
   ansible.posix.firewalld:
     port: "{{ prometheus_port }}/tcp"
     permanent: true
     state: enabled
-    immediate: true
     offline: true
-  when: firewalld_status.status.ActiveState == "active"
+  when: firewalld_installed
+  notify:
+    - Restart firewalld if running

--- a/roles/proxy/tasks/cleanup.yml
+++ b/roles/proxy/tasks/cleanup.yml
@@ -7,19 +7,15 @@
   notify:
     - Restart nginx
 
-- name: Check the status of firewalld
-  ansible.builtin.systemd:
-    name: firewalld.service
-  register: firewalld_status
-
 - name: Close http and https ports using firewalld
   ansible.posix.firewalld:
     port: "{{ item }}"
     permanent: true
     state: disabled
-    immediate: true
     offline: true
   loop:
     - "{{ nginx_vhost_http_listen_port }}/tcp"
     - "{{ nginx_vhost_https_listen_port }}/tcp"
-  when: firewalld_status.status.ActiveState == "active"
+  when: firewalld_installed
+  notify:
+    - Restart firewalld if running

--- a/roles/proxy/tasks/cleanup.yml
+++ b/roles/proxy/tasks/cleanup.yml
@@ -7,12 +7,19 @@
   notify:
     - Restart nginx
 
+- name: Check the status of firewalld
+  ansible.builtin.systemd:
+    name: firewalld.service
+  register: firewalld_status
+
 - name: Close http and https ports using firewalld
   ansible.posix.firewalld:
     port: "{{ item }}"
     permanent: true
     state: disabled
     immediate: true
+    offline: true
   loop:
     - "{{ nginx_vhost_http_listen_port }}/tcp"
     - "{{ nginx_vhost_https_listen_port }}/tcp"
+  when: firewalld_status.status.ActiveState == "active"

--- a/roles/proxy/tasks/main.yml
+++ b/roles/proxy/tasks/main.yml
@@ -59,12 +59,19 @@
     state: started
     enabled: true
 
+- name: Check the status of firewalld
+  ansible.builtin.systemd:
+    name: firewalld.service
+  register: firewalld_status
+
 - name: Open HTTP and HTTPS ports in firewalld
   ansible.posix.firewalld:
     port: "{{ item }}"
     permanent: true
     state: enabled
     immediate: true
+    offline: true
   loop:
     - "{{ nginx_vhost_http_listen_port }}/tcp"
     - "{{ nginx_vhost_https_listen_port }}/tcp"
+  when: firewalld_status.status.ActiveState == "active"

--- a/roles/proxy/tasks/main.yml
+++ b/roles/proxy/tasks/main.yml
@@ -59,19 +59,15 @@
     state: started
     enabled: true
 
-- name: Check the status of firewalld
-  ansible.builtin.systemd:
-    name: firewalld.service
-  register: firewalld_status
-
 - name: Open HTTP and HTTPS ports in firewalld
   ansible.posix.firewalld:
     port: "{{ item }}"
     permanent: true
     state: enabled
-    immediate: true
     offline: true
   loop:
     - "{{ nginx_vhost_http_listen_port }}/tcp"
     - "{{ nginx_vhost_https_listen_port }}/tcp"
-  when: firewalld_status.status.ActiveState == "active"
+  when: firewalld_installed
+  notify:
+    - Restart firewalld if running


### PR DESCRIPTION
This PR will prevent the firewalld exceptions from being applied  / removed when the firewalld service is not active, as this would cause the playbook execution to fail.