### PR TITLE
Temporary HTTPS Fix 

### DIFF
--- a/roles/proxy/templates/trento.conf.j2
+++ b/roles/proxy/templates/trento.conf.j2
@@ -57,6 +57,9 @@ server {
     proxy_set_header Host $http_host;
     proxy_set_header X-Cluster-Client-Ip $remote_addr;
 
+    #Temporary workaround to avoid websocket issues using https
+    proxy_set_header Origin "";
+
     # The Important Websocket Bits!
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection "upgrade";


### PR DESCRIPTION
This temporary fixes the issues with https ad websockets in trento web.
It injects an empty origin to bypass the phoenix websocket origin checking.

This is a temporary workaround