### PR TITLE
Improve log message for verify alerting env's step

### DIFF
--- a/roles/containers/tasks/main.yml
+++ b/roles/containers/tasks/main.yml
@@ -47,7 +47,7 @@
       AMQP_URL: "{{ amqp_protocol }}://{{ rabbitmq_username }}:{{ rabbitmq_password }}@{{ rabbitmq_host }}/{{ rabbitmq_vhost | urlencode | replace('/', '%2F') }}"
       DATABASE_URL: "ecto://{{ wanda_postgres_user }}:{{ wanda_postgres_password }}@{{ wanda_postgres_host }}/{{ wanda_postgres_db }}"
 
-- name: Verify that alerting configuration variables are defined in json configuration if alerting is enabled
+- name: Verify that alerting configuration variables are defined if alerting is enabled
   ansible.builtin.assert:
     that:
       - alerting_env is defined
@@ -55,8 +55,8 @@
       - "{{ lookup('vars', alerting_env) != None }}"
       - "{{ lookup('vars', alerting_env) != '' }}"
 
-    fail_msg: "{{ alerting_env }} needs to be set in json configuration to enable alerting"
-    success_msg: "{{ alerting_env }} is set in json configuration"
+    fail_msg: "{{ alerting_env }} needs to be set in playbook variables to enable alerting"
+    success_msg: "{{ alerting_env }} is set in playbook variables"
   loop_control:
     loop_var: alerting_env
   with_items:


### PR DESCRIPTION
A small follow-up PR to improve the fail and success msg in the role containers tasks in the "Verify that alerting configuration ..." step

Thanks to @CDimonaco for pointing out :+1:  that json configuration may not be the correct naming. Changed to playbook variables.