### PR TITLE
Fix nginx_vhost_filename and rabbitmq_vhost usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ These variables are the defaults of our roles, if you want to override the prope
 | nginx_ssl_cert_as_base64 | Nginx ssl certificate provided as base64 string | false |
 | nginx_ssl_key_as_base64 | Nginx ssl key provided as base64 string | false |
 | override_nginx_default_conf | Override the default nginx configuration, this will delete the default nginx page and put a configuration that will use the vhosts according to an opinionated directory structure | true |
-| nginx_conf_filename | Nginx vhost filename. "conf" suffix is added to the given name | trento |
+| nginx_vhost_filename | Nginx vhost filename. "conf" suffix is added to the given name | trento |
 | nginx_vhost_http_listen_port | Configure the http listen port for trento (redirects to https by default) | 80 |
 | nginx_vhost_https_listen_port | Configure the https listen port for trento | 443 |
 | enable_api_key | Enable/Disable API key usage. Mostly for testing purposes | true |

--- a/roles/agent/defaults/main.yml
+++ b/roles/agent/defaults/main.yml
@@ -2,4 +2,5 @@
 trento_server_url: http://localhost:4000
 trento_repository: "https://download.opensuse.org/repositories/devel:sap:trento:factory/SLE_15_SP3/"
 rabbitmq_username: trento
+rabbitmq_vhost: trento
 rabbitmq_host: localhost:5672

--- a/roles/agent/defaults/main.yml
+++ b/roles/agent/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 trento_server_url: http://localhost:4000
 trento_repository: "https://download.opensuse.org/repositories/devel:sap:trento:factory/SLE_15_SP3/"
+amqp_protocol: amqp
 rabbitmq_username: trento
 rabbitmq_vhost: trento
 rabbitmq_host: localhost:5672

--- a/roles/agent/tasks/main.yml
+++ b/roles/agent/tasks/main.yml
@@ -20,7 +20,7 @@
   vars:
     server_url: "{{ trento_server_url }}"
     api_key: "{{ trento_api_key }}"
-    facts_service_url: "amqp://{{ rabbitmq_username }}:{{ rabbitmq_password }}@{{ rabbitmq_host }}"
+    facts_service_url: "amqp://{{ rabbitmq_username }}:{{ rabbitmq_password }}@{{ rabbitmq_host }}/{{ rabbitmq_vhost }}"
   notify:
     - Restart Trento agent
 

--- a/roles/agent/tasks/main.yml
+++ b/roles/agent/tasks/main.yml
@@ -20,7 +20,7 @@
   vars:
     server_url: "{{ trento_server_url }}"
     api_key: "{{ trento_api_key }}"
-    facts_service_url: "amqp://{{ rabbitmq_username }}:{{ rabbitmq_password }}@{{ rabbitmq_host }}/{{ rabbitmq_vhost }}"
+    facts_service_url: "{{ amqp_protocol }}://{{ rabbitmq_username }}:{{ rabbitmq_password }}@{{ rabbitmq_host }}/{{ rabbitmq_vhost | urlencode | replace('/', '%2F') }}"
   notify:
     - Restart Trento agent
 

--- a/roles/proxy/defaults/main.yml
+++ b/roles/proxy/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 install_nginx: "true"
 override_nginx_default_conf: "true"
-nginx_conf_filename: "trento"
+nginx_vhost_filename: "trento"
 nginx_vhost_http_listen_port: "80"
 nginx_vhost_https_listen_port: "443"
 web_upstream_name: "web"


### PR DESCRIPTION
Fix a couple of default values and usages:
- `nginx_vhost_filename`, it was not updated from `nginx_conf_filename`
- `rabbitmq_vhost value` in agent side