### PR TITLE
Workaround to allow installation with newer ncurses

### DIFF
--- a/roles/postgres/tasks/main.yml
+++ b/roles/postgres/tasks/main.yml
@@ -4,12 +4,20 @@
   when: install_postgres == 'true'
   community.general.zypper:
     name:
-      - postgresql
-      - postgresql-server
-      - postgresql-server-devel
-      - postgresql-contrib
+      - postgresql15
+      - postgresql15-server
+      - postgresql15-contrib
     state: present
     update_cache: true
+
+
+- name: Install postgresql-server-devel manually using expect module
+  ansible.builtin.expect:
+    command: zypper install postgresql15-server-devel
+    responses:
+      (?i)Choose from above solutions by number or cancel: "3"
+      (?i)Continue?: "y"
+      (?i)Continue? [y/n/v/...? shows all options] (y): "y"
 
 - name: Install postgres python management deps
   ansible.builtin.pip:


### PR DESCRIPTION
This PR includes a workaround to allow the installation of the postgres role in azure-based SLES 15 SP3 installations.

For a bit of context: our azure SLES images are built using core packages newer than what's usually available in the SLES 15 SP3 repos, causing that some packages that don't come preinstalled show conflicts during the installation. This workaround will be able to force the installation under such circumstances while still allow a regular SP3 installation to work.