### PR TITLE
Add RPM tests for SP3, SP4, SP5

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Run ansible-lint
         uses: ansible/ansible-lint-action@v6
-        
+
   build-and-push-container-images:
     name: Build and push container images
     runs-on: ubuntu-latest
@@ -61,6 +61,273 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  deploy-test-sp3-rpm:
+    name: Run the playbook on SLES 15 SP3
+    runs-on: ubuntu-latest
+    needs: [build-and-push-container-images]
+    env:
+      TEST_SP3_HOST_IP: ${{ secrets.TEST_SP3_HOST_IP }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install galaxy deps
+        run: ansible-galaxy install -r requirements.yml
+      - name: Run playbook
+        uses: dawidd6/action-ansible-playbook@v2
+        with:
+          playbook: playbook.yml
+          key: ${{ secrets.SSH_MACHINE_KEY }}
+          inventory: |
+            all:
+              vars:
+                ansible_user: ${{ secrets.TEST_HOST_USER }}
+              children:
+                trento-server:
+                  hosts:
+                    server:
+                      ansible_host: ${{ secrets.TEST_SP3_HOST_IP }}
+                postgres-hosts:
+                  hosts:
+                    server:
+                      ansible_host: ${{ secrets.TEST_SP3_HOST_IP }}
+                rabbitmq-hosts:
+                  hosts:
+                    server:
+                      ansible_host: ${{ secrets.TEST_SP3_HOST_IP }}
+          options: |
+            --extra-vars "web_postgres_password='trento' \
+            wanda_postgres_password='wanda' \
+            rabbitmq_password='trento' \
+            prometheus_url='http://localhost' \
+            trento_server_name='trento-deployment.example.com' \
+            web_admin_password='adminpassword' \
+            enable_api_key='false' \
+            nginx_vhost_listen_port='443' \
+            nginx_ssl_cert_as_base64='true' \
+            nginx_ssl_key_as_base64='true' \
+            nginx_ssl_cert='${{ secrets.SSL_CERT }}' \
+            nginx_ssl_key='${{ secrets.SSL_KEY }}' \
+            install_method='rpm'"
+      - name: Test readyness
+        run: curl -k "https://$TEST_SP3_HOST_IP/api/readyz"
+      - name: Run playbook cleanup
+        uses: dawidd6/action-ansible-playbook@v2
+        with:
+          playbook: playbook.cleanup.yml
+          key: ${{ secrets.SSH_MACHINE_KEY }}
+          inventory: |
+            all:
+              vars:
+                ansible_user: ${{ secrets.TEST_HOST_USER }}
+              children:
+                trento-server:
+                  hosts:
+                    server:
+                      ansible_host: ${{ secrets.TEST_SP3_HOST_IP }}
+                postgres-hosts:
+                  hosts:
+                    server:
+                      ansible_host: ${{ secrets.TEST_SP3_HOST_IP }}
+                rabbitmq-hosts:
+                  hosts:
+                    server:
+                      ansible_host: ${{ secrets.TEST_SP3_HOST_IP }}
+          options: |
+            --extra-vars "web_postgres_password='trento' \
+            wanda_postgres_password='wanda' \
+            rabbitmq_password='trento' \
+            prometheus_url='http://localhost' \
+            trento_server_name='trento-deployment.example.com' \
+            web_admin_password='adminpassword' \
+            enable_api_key='false' \
+            nginx_vhost_listen_port='443' \
+            nginx_ssl_cert_as_base64='true' \
+            nginx_ssl_key_as_base64='true' \
+            nginx_ssl_cert='${{ secrets.SSL_CERT }}' \
+            nginx_ssl_key='${{ secrets.SSL_KEY }}' \
+            install_method='rpm'"
+
+  deploy-test-sp4-rpm:
+    name: Run the playbook on SLES 15 SP4
+    runs-on: ubuntu-latest
+    needs: [build-and-push-container-images]
+    env:
+      TEST_SP4_HOST_IP: ${{ secrets.TEST_SP4_HOST_IP }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install galaxy deps
+        run: ansible-galaxy install -r requirements.yml
+      - name: Run playbook
+        uses: dawidd6/action-ansible-playbook@v2
+        with:
+          playbook: playbook.yml
+          key: ${{ secrets.SSH_MACHINE_KEY }}
+          inventory: |
+            all:
+              vars:
+                ansible_user: ${{ secrets.TEST_HOST_USER }}
+              children:
+                trento-server:
+                  hosts:
+                    server:
+                      ansible_host: ${{ secrets.TEST_SP4_HOST_IP }}
+                postgres-hosts:
+                  hosts:
+                    server:
+                      ansible_host: ${{ secrets.TEST_SP4_HOST_IP }}
+                rabbitmq-hosts:
+                  hosts:
+                    server:
+                      ansible_host: ${{ secrets.TEST_SP4_HOST_IP }}
+          options: |
+            --extra-vars "web_postgres_password='trento' \
+            wanda_postgres_password='wanda' \
+            rabbitmq_password='trento' \
+            prometheus_url='http://localhost' \
+            trento_server_name='trento-deployment.example.com' \
+            web_admin_password='adminpassword' \
+            enable_api_key='false' \
+            nginx_vhost_listen_port='443' \
+            nginx_ssl_cert_as_base64='true' \
+            nginx_ssl_key_as_base64='true' \
+            nginx_ssl_cert='${{ secrets.SSL_CERT }}' \
+            nginx_ssl_key='${{ secrets.SSL_KEY }}' \
+            install_method='rpm'"
+      - name: Test readyness
+        run: curl -k "https://$TEST_SP4_HOST_IP/api/readyz"
+      - name: Run playbook cleanup
+        uses: dawidd6/action-ansible-playbook@v2
+        with:
+          playbook: playbook.cleanup.yml
+          key: ${{ secrets.SSH_MACHINE_KEY }}
+          inventory: |
+            all:
+              vars:
+                ansible_user: ec2-user
+              children:
+                trento-server:
+                  hosts:
+                    server:
+                      ansible_host: ${{ secrets.TEST_SP4_HOST_IP }}
+                      ansible_user: ${{ secrets.TEST_HOST_USER }}
+                postgres-hosts:
+                  hosts:
+                    server:
+                      ansible_host: ${{ secrets.TEST_SP4_HOST_IP }}
+                      ansible_user: ${{ secrets.TEST_HOST_USER }}
+                rabbitmq-hosts:
+                  hosts:
+                    server:
+                      ansible_host: ${{ secrets.TEST_SP4_HOST_IP }}
+                      ansible_user: ${{ secrets.TEST_HOST_USER }}
+          options: |
+            --extra-vars "web_postgres_password='trento' \
+            wanda_postgres_password='wanda' \
+            rabbitmq_password='trento' \
+            prometheus_url='http://localhost' \
+            trento_server_name='trento-deployment.example.com' \
+            web_admin_password='adminpassword' \
+            enable_api_key='false' \
+            nginx_vhost_listen_port='443' \
+            nginx_ssl_cert_as_base64='true' \
+            nginx_ssl_key_as_base64='true' \
+            nginx_ssl_cert='${{ secrets.SSL_CERT }}' \
+            nginx_ssl_key='${{ secrets.SSL_KEY }}' \
+            install_method='rpm'"
+
+  deploy-test-sp5-rpm:
+    name: Run the playbook on SLES 15 SP5
+    runs-on: ubuntu-latest
+    needs: [build-and-push-container-images]
+    env:
+      TEST_SP5_HOST_IP: ${{ secrets.TEST_SP5_HOST_IP }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install galaxy deps
+        run: ansible-galaxy install -r requirements.yml
+      - name: Run playbook
+        uses: dawidd6/action-ansible-playbook@v2
+        with:
+          playbook: playbook.yml
+          key: ${{ secrets.SSH_MACHINE_KEY }}
+          inventory: |
+            all:
+              vars:
+                ansible_user: ${{ secrets.TEST_HOST_USER }}
+              children:
+                trento-server:
+                  hosts:
+                    server:
+                      ansible_host: ${{ secrets.TEST_SP5_HOST_IP }}
+                postgres-hosts:
+                  hosts:
+                    server:
+                      ansible_host: ${{ secrets.TEST_SP5_HOST_IP }}
+                rabbitmq-hosts:
+                  hosts:
+                    server:
+                      ansible_host: ${{ secrets.TEST_SP5_HOST_IP }}
+          options: |
+            --extra-vars "web_postgres_password='trento' \
+            wanda_postgres_password='wanda' \
+            rabbitmq_password='trento' \
+            prometheus_url='http://localhost' \
+            trento_server_name='trento-deployment.example.com' \
+            web_admin_password='adminpassword' \
+            enable_api_key='false' \
+            nginx_vhost_listen_port='443' \
+            nginx_ssl_cert_as_base64='true' \
+            nginx_ssl_key_as_base64='true' \
+            nginx_ssl_cert='${{ secrets.SSL_CERT }}' \
+            nginx_ssl_key='${{ secrets.SSL_KEY }}' \
+            install_method='rpm'"
+      - name: Test readyness
+        run: curl -k "https://$TEST_SP5_HOST_IP/api/readyz"
+      - name: Run playbook cleanup
+        uses: dawidd6/action-ansible-playbook@v2
+        with:
+          playbook: playbook.cleanup.yml
+          key: ${{ secrets.SSH_MACHINE_KEY }}
+          inventory: |
+            all:
+              vars:
+                ansible_user: ${{ secrets.TEST_HOST_USER }}
+              children:
+                trento-server:
+                  hosts:
+                    server:
+                      ansible_host: ${{ secrets.TEST_SP5_HOST_IP }}
+                postgres-hosts:
+                  hosts:
+                    server:
+                      ansible_host: ${{ secrets.TEST_SP5_HOST_IP }}
+                rabbitmq-hosts:
+                  hosts:
+                    server:
+                      ansible_host: ${{ secrets.TEST_SP5_HOST_IP }}
+          options: |
+            --extra-vars "web_postgres_password='trento' \
+            wanda_postgres_password='wanda' \
+            rabbitmq_password='trento' \
+            prometheus_url='http://localhost' \
+            trento_server_name='trento-deployment.example.com' \
+            web_admin_password='adminpassword' \
+            enable_api_key='false' \
+            nginx_vhost_listen_port='443' \
+            nginx_ssl_cert_as_base64='true' \
+            nginx_ssl_key_as_base64='true' \
+            nginx_ssl_cert='${{ secrets.SSL_CERT }}' \
+            nginx_ssl_key='${{ secrets.SSL_KEY }}' \
+            install_method='rpm'"
 
   create-artifact:
     runs-on: ubuntu-20.04
@@ -108,4 +375,3 @@ jobs:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: trento-ansible.tgz
           tag: ${{ github.ref }}
-      

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -68,16 +68,15 @@ jobs:
     needs: [build-and-push-container-images]
     strategy:
       matrix:
-        sp_version: ['SP3', 'SP4', 'SP5']
         include:
           - sp_version: 'SP3'
-            host_ip: ${{ secrets.TEST_SP3_HOST_IP }}
+            host_ip: TEST_SP3_HOST_IP
           - sp_version: 'SP4'
-            host_ip: ${{ secrets.TEST_SP4_HOST_IP }}
+            host_ip: TEST_SP4_HOST_IP
           - sp_version: 'SP5'
-            host_ip: ${{ secrets.TEST_SP5_HOST_IP }}
+            host_ip: TEST_SP5_HOST_IP
     env:
-      TEST_HOST_IP: ${{ matrix.host_ip }}
+      TEST_HOST_IP: ${{ secrets[matrix.host_ip] }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
 
   build-and-push-container-images:
     name: Build and push container images
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.event_name == 'release' || (github.event_name == 'push' && github.ref_name == 'main')
     needs: [ansible-lint]
     permissions:
@@ -62,12 +62,22 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-  deploy-test-sp3-rpm:
-    name: Run the playbook on SLES 15 SP3
-    runs-on: ubuntu-latest
+  deploy-test-rpm:
+    name: Run the playbook on SLES 15 ${{ matrix.sp_version }}
+    runs-on: ubuntu-22.04
     needs: [build-and-push-container-images]
+    strategy:
+      matrix:
+        sp_version: ['SP3', 'SP4', 'SP5']
+        include:
+          - sp_version: 'SP3'
+            host_ip: ${{ secrets.TEST_SP3_HOST_IP }}
+          - sp_version: 'SP4'
+            host_ip: ${{ secrets.TEST_SP4_HOST_IP }}
+          - sp_version: 'SP5'
+            host_ip: ${{ secrets.TEST_SP5_HOST_IP }}
     env:
-      TEST_SP3_HOST_IP: ${{ secrets.TEST_SP3_HOST_IP }}
+      TEST_HOST_IP: ${{ matrix.host_ip }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -88,15 +98,15 @@ jobs:
                 trento-server:
                   hosts:
                     server:
-                      ansible_host: ${{ secrets.TEST_SP3_HOST_IP }}
+                      ansible_host: ${{ env.TEST_HOST_IP }}
                 postgres-hosts:
                   hosts:
                     server:
-                      ansible_host: ${{ secrets.TEST_SP3_HOST_IP }}
+                      ansible_host: ${{ env.TEST_HOST_IP }}
                 rabbitmq-hosts:
                   hosts:
                     server:
-                      ansible_host: ${{ secrets.TEST_SP3_HOST_IP }}
+                      ansible_host: ${{ env.TEST_HOST_IP }}
           options: |
             --extra-vars "web_postgres_password='trento' \
             wanda_postgres_password='wanda' \
@@ -111,8 +121,8 @@ jobs:
             nginx_ssl_cert='${{ secrets.SSL_CERT }}' \
             nginx_ssl_key='${{ secrets.SSL_KEY }}' \
             install_method='rpm'"
-      - name: Test readyness
-        run: curl -k "https://$TEST_SP3_HOST_IP/api/readyz"
+      - name: Test readiness
+        run: curl -k "https://${{ env.TEST_HOST_IP }}/api/readyz"
       - name: Run playbook cleanup
         uses: dawidd6/action-ansible-playbook@v2
         with:
@@ -126,194 +136,15 @@ jobs:
                 trento-server:
                   hosts:
                     server:
-                      ansible_host: ${{ secrets.TEST_SP3_HOST_IP }}
+                      ansible_host: ${{ env.TEST_HOST_IP }}
                 postgres-hosts:
                   hosts:
                     server:
-                      ansible_host: ${{ secrets.TEST_SP3_HOST_IP }}
+                      ansible_host: ${{ env.TEST_HOST_IP }}
                 rabbitmq-hosts:
                   hosts:
                     server:
-                      ansible_host: ${{ secrets.TEST_SP3_HOST_IP }}
-          options: |
-            --extra-vars "web_postgres_password='trento' \
-            wanda_postgres_password='wanda' \
-            rabbitmq_password='trento' \
-            prometheus_url='http://localhost' \
-            trento_server_name='trento-deployment.example.com' \
-            web_admin_password='adminpassword' \
-            enable_api_key='false' \
-            nginx_vhost_listen_port='443' \
-            nginx_ssl_cert_as_base64='true' \
-            nginx_ssl_key_as_base64='true' \
-            nginx_ssl_cert='${{ secrets.SSL_CERT }}' \
-            nginx_ssl_key='${{ secrets.SSL_KEY }}' \
-            install_method='rpm'"
-
-  deploy-test-sp4-rpm:
-    name: Run the playbook on SLES 15 SP4
-    runs-on: ubuntu-latest
-    needs: [build-and-push-container-images]
-    env:
-      TEST_SP4_HOST_IP: ${{ secrets.TEST_SP4_HOST_IP }}
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Install galaxy deps
-        run: ansible-galaxy install -r requirements.yml
-      - name: Run playbook
-        uses: dawidd6/action-ansible-playbook@v2
-        with:
-          playbook: playbook.yml
-          key: ${{ secrets.SSH_MACHINE_KEY }}
-          inventory: |
-            all:
-              vars:
-                ansible_user: ${{ secrets.TEST_HOST_USER }}
-              children:
-                trento-server:
-                  hosts:
-                    server:
-                      ansible_host: ${{ secrets.TEST_SP4_HOST_IP }}
-                postgres-hosts:
-                  hosts:
-                    server:
-                      ansible_host: ${{ secrets.TEST_SP4_HOST_IP }}
-                rabbitmq-hosts:
-                  hosts:
-                    server:
-                      ansible_host: ${{ secrets.TEST_SP4_HOST_IP }}
-          options: |
-            --extra-vars "web_postgres_password='trento' \
-            wanda_postgres_password='wanda' \
-            rabbitmq_password='trento' \
-            prometheus_url='http://localhost' \
-            trento_server_name='trento-deployment.example.com' \
-            web_admin_password='adminpassword' \
-            enable_api_key='false' \
-            nginx_vhost_listen_port='443' \
-            nginx_ssl_cert_as_base64='true' \
-            nginx_ssl_key_as_base64='true' \
-            nginx_ssl_cert='${{ secrets.SSL_CERT }}' \
-            nginx_ssl_key='${{ secrets.SSL_KEY }}' \
-            install_method='rpm'"
-      - name: Test readyness
-        run: curl -k "https://$TEST_SP4_HOST_IP/api/readyz"
-      - name: Run playbook cleanup
-        uses: dawidd6/action-ansible-playbook@v2
-        with:
-          playbook: playbook.cleanup.yml
-          key: ${{ secrets.SSH_MACHINE_KEY }}
-          inventory: |
-            all:
-              vars:
-                ansible_user: ec2-user
-              children:
-                trento-server:
-                  hosts:
-                    server:
-                      ansible_host: ${{ secrets.TEST_SP4_HOST_IP }}
-                      ansible_user: ${{ secrets.TEST_HOST_USER }}
-                postgres-hosts:
-                  hosts:
-                    server:
-                      ansible_host: ${{ secrets.TEST_SP4_HOST_IP }}
-                      ansible_user: ${{ secrets.TEST_HOST_USER }}
-                rabbitmq-hosts:
-                  hosts:
-                    server:
-                      ansible_host: ${{ secrets.TEST_SP4_HOST_IP }}
-                      ansible_user: ${{ secrets.TEST_HOST_USER }}
-          options: |
-            --extra-vars "web_postgres_password='trento' \
-            wanda_postgres_password='wanda' \
-            rabbitmq_password='trento' \
-            prometheus_url='http://localhost' \
-            trento_server_name='trento-deployment.example.com' \
-            web_admin_password='adminpassword' \
-            enable_api_key='false' \
-            nginx_vhost_listen_port='443' \
-            nginx_ssl_cert_as_base64='true' \
-            nginx_ssl_key_as_base64='true' \
-            nginx_ssl_cert='${{ secrets.SSL_CERT }}' \
-            nginx_ssl_key='${{ secrets.SSL_KEY }}' \
-            install_method='rpm'"
-
-  deploy-test-sp5-rpm:
-    name: Run the playbook on SLES 15 SP5
-    runs-on: ubuntu-latest
-    needs: [build-and-push-container-images]
-    env:
-      TEST_SP5_HOST_IP: ${{ secrets.TEST_SP5_HOST_IP }}
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Install galaxy deps
-        run: ansible-galaxy install -r requirements.yml
-      - name: Run playbook
-        uses: dawidd6/action-ansible-playbook@v2
-        with:
-          playbook: playbook.yml
-          key: ${{ secrets.SSH_MACHINE_KEY }}
-          inventory: |
-            all:
-              vars:
-                ansible_user: ${{ secrets.TEST_HOST_USER }}
-              children:
-                trento-server:
-                  hosts:
-                    server:
-                      ansible_host: ${{ secrets.TEST_SP5_HOST_IP }}
-                postgres-hosts:
-                  hosts:
-                    server:
-                      ansible_host: ${{ secrets.TEST_SP5_HOST_IP }}
-                rabbitmq-hosts:
-                  hosts:
-                    server:
-                      ansible_host: ${{ secrets.TEST_SP5_HOST_IP }}
-          options: |
-            --extra-vars "web_postgres_password='trento' \
-            wanda_postgres_password='wanda' \
-            rabbitmq_password='trento' \
-            prometheus_url='http://localhost' \
-            trento_server_name='trento-deployment.example.com' \
-            web_admin_password='adminpassword' \
-            enable_api_key='false' \
-            nginx_vhost_listen_port='443' \
-            nginx_ssl_cert_as_base64='true' \
-            nginx_ssl_key_as_base64='true' \
-            nginx_ssl_cert='${{ secrets.SSL_CERT }}' \
-            nginx_ssl_key='${{ secrets.SSL_KEY }}' \
-            install_method='rpm'"
-      - name: Test readyness
-        run: curl -k "https://$TEST_SP5_HOST_IP/api/readyz"
-      - name: Run playbook cleanup
-        uses: dawidd6/action-ansible-playbook@v2
-        with:
-          playbook: playbook.cleanup.yml
-          key: ${{ secrets.SSH_MACHINE_KEY }}
-          inventory: |
-            all:
-              vars:
-                ansible_user: ${{ secrets.TEST_HOST_USER }}
-              children:
-                trento-server:
-                  hosts:
-                    server:
-                      ansible_host: ${{ secrets.TEST_SP5_HOST_IP }}
-                postgres-hosts:
-                  hosts:
-                    server:
-                      ansible_host: ${{ secrets.TEST_SP5_HOST_IP }}
-                rabbitmq-hosts:
-                  hosts:
-                    server:
-                      ansible_host: ${{ secrets.TEST_SP5_HOST_IP }}
+                      ansible_host: ${{ env.TEST_HOST_IP }}
           options: |
             --extra-vars "web_postgres_password='trento' \
             wanda_postgres_password='wanda' \


### PR DESCRIPTION
This PR adds some basic testing for the playbooks, using the RPM installation method in
 - SP3
 - SP4
 - SP5
 
 It: 
  - Runs `playbook.yml`
  - Does a simple curl test to the readyness endpoint (`/api/readyz`
  - Runs `playbook.cleanup.yml`
  
  3 new machines have been deployed in azure for this purpose. I'm currently adding the required variables to the repository secrets