### PR TITLE
Make use of the new TRENTO_DOMAIN env var required for WSS

### DIFF
--- a/roles/app/tasks/docker.yml
+++ b/roles/app/tasks/docker.yml
@@ -101,3 +101,4 @@
       ADMIN_PASSWORD: "{{ web_admin_password }}"
       ENABLE_API_KEY: "{{ enable_api_key }}"
       CHARTS_ENABLED: "{{ enable_charts }}"
+      TRENTO_DOMAIN: "{{ trento_server_name }}"

--- a/roles/app/templates/trento-web.j2
+++ b/roles/app/templates/trento-web.j2
@@ -17,3 +17,4 @@ ADMIN_PASSWORD={{ web_admin_password }}
 ENABLE_API_KEY={{ enable_api_key }}
 CHARTS_ENABLED={{ enable_charts }}
 PORT={{ web_listen_port }}
+TRENTO_DOMAIN={{ trento_server_name }}

--- a/roles/proxy/templates/trento.conf.j2
+++ b/roles/proxy/templates/trento.conf.j2
@@ -57,9 +57,6 @@ server {
     proxy_set_header Host $http_host;
     proxy_set_header X-Cluster-Client-Ip $remote_addr;
 
-    #Temporary workaround to avoid websocket issues using https
-    proxy_set_header Origin "";
-
     # The Important Websocket Bits!
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection "upgrade";


### PR DESCRIPTION
This PR makes use of the en var added in https://github.com/trento-project/web/pull/2671
Setting to draft until:
 - merge freeze is over
 - the menitoned PR is merged