### PR TITLE
Rename `TRENTO_DOMAIN` to `TRENTO_WEB_ORIGIN`

### DIFF
--- a/roles/app/tasks/docker.yml
+++ b/roles/app/tasks/docker.yml
@@ -101,4 +101,4 @@
       ADMIN_PASSWORD: "{{ web_admin_password }}"
       ENABLE_API_KEY: "{{ enable_api_key }}"
       CHARTS_ENABLED: "{{ enable_charts }}"
-      TRENTO_DOMAIN: "{{ trento_server_name }}"
+      TRENTO_WEB_ORIGIN: "{{ trento_server_name }}"

--- a/roles/app/templates/trento-web.j2
+++ b/roles/app/templates/trento-web.j2
@@ -17,4 +17,4 @@ ADMIN_PASSWORD={{ web_admin_password }}
 ENABLE_API_KEY={{ enable_api_key }}
 CHARTS_ENABLED={{ enable_charts }}
 PORT={{ web_listen_port }}
-TRENTO_DOMAIN={{ trento_server_name }}
+TRENTO_WEB_ORIGIN={{ trento_server_name }}


### PR DESCRIPTION
Just a tiny fix. Please confirm I did not forget anything 😄