### PR TITLE
Allow cleanup(test) to run regardless of deployment

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
 
   build-and-push-container-images:
     name: Build and push container images
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     if: github.event_name == 'release' || (github.event_name == 'push' && github.ref_name == 'main')
     needs: [ansible-lint]
     permissions:
@@ -65,7 +65,7 @@ jobs:
 
   deploy-test-rpm:
     name: Run the playbook on SLES 15 ${{ matrix.sp_version }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         include:
@@ -94,6 +94,7 @@ jobs:
             all:
               vars:
                 ansible_user: ${{ secrets.TEST_HOST_USER }}
+                ansible_python_interpreter: /usr/bin/python3
               children:
                 trento-server:
                   hosts:
@@ -133,6 +134,7 @@ jobs:
             all:
               vars:
                 ansible_user: ${{ secrets.TEST_HOST_USER }}
+                ansible_python_interpreter: /usr/bin/python3
               children:
                 trento-server:
                   hosts:
@@ -163,7 +165,7 @@ jobs:
 
   create-artifact:
     runs-on: ubuntu-20.04
-    needs: [ansible-lint]
+    needs: [ansible-lint, deploy-test-rpm]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,7 +67,6 @@ jobs:
     name: Run the playbook on SLES 15 ${{ matrix.sp_version }}
     runs-on: ubuntu-22.04
     needs: [build-and-push-container-images]
-    continue-on-error: true
     strategy:
       matrix:
         include:
@@ -87,6 +86,7 @@ jobs:
       - name: Install galaxy deps
         run: ansible-galaxy install -r requirements.yml
       - name: Run playbook
+        id: runplaybook
         uses: dawidd6/action-ansible-playbook@v2
         with:
           playbook: playbook.yml
@@ -124,29 +124,9 @@ jobs:
             install_method='rpm'"
       - name: Test readiness
         run: curl -k "https://${{ env.TEST_HOST_IP }}/api/readyz"
-
-  cleanup:
-    name: Cleanup after playbook run
-    runs-on: ubuntu-22.04
-    needs: [deploy-test-rpm]
-    strategy:
-      matrix:
-        include:
-          - sp_version: 'SP3'
-            host_ip: TEST_SP3_HOST_IP
-          - sp_version: 'SP4'
-            host_ip: TEST_SP4_HOST_IP
-          - sp_version: 'SP5'
-            host_ip: TEST_SP5_HOST_IP
-    env:
-      TEST_HOST_IP: ${{ secrets[matrix.host_ip] }}
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - name: Run playbook cleanup
         uses: dawidd6/action-ansible-playbook@v2
+        if: success() || steps.runplaybook.conclusion == 'failure'
         with:
           playbook: playbook.cleanup.yml
           key: ${{ secrets.SSH_MACHINE_KEY }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
     name: Build and push container images
     runs-on: ubuntu-20.04
     if: github.event_name == 'release' || (github.event_name == 'push' && github.ref_name == 'main')
-    needs: [ansible-lint]
+    needs: [ansible-lint, deploy-test-rpm]
     permissions:
       contents: read
       packages: write
@@ -65,6 +65,7 @@ jobs:
 
   deploy-test-rpm:
     name: Run the playbook on SLES 15 ${{ matrix.sp_version }}
+    needs: [ansible-lint]
     runs-on: ubuntu-20.04
     strategy:
       matrix:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,6 +67,7 @@ jobs:
     name: Run the playbook on SLES 15 ${{ matrix.sp_version }}
     runs-on: ubuntu-22.04
     needs: [build-and-push-container-images]
+    continue-on-error: true
     strategy:
       matrix:
         include:
@@ -128,7 +129,6 @@ jobs:
     name: Cleanup after playbook run
     runs-on: ubuntu-22.04
     needs: [deploy-test-rpm]
-    if: always()
     strategy:
       matrix:
         include:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -123,6 +123,28 @@ jobs:
             install_method='rpm'"
       - name: Test readiness
         run: curl -k "https://${{ env.TEST_HOST_IP }}/api/readyz"
+
+  cleanup:
+    name: Cleanup after playbook run
+    runs-on: ubuntu-22.04
+    needs: [deploy-test-rpm]
+    if: always()
+    strategy:
+      matrix:
+        include:
+          - sp_version: 'SP3'
+            host_ip: TEST_SP3_HOST_IP
+          - sp_version: 'SP4'
+            host_ip: TEST_SP4_HOST_IP
+          - sp_version: 'SP5'
+            host_ip: TEST_SP5_HOST_IP
+    env:
+      TEST_HOST_IP: ${{ secrets[matrix.host_ip] }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Run playbook cleanup
         uses: dawidd6/action-ansible-playbook@v2
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,7 +66,6 @@ jobs:
   deploy-test-rpm:
     name: Run the playbook on SLES 15 ${{ matrix.sp_version }}
     runs-on: ubuntu-22.04
-    needs: [build-and-push-container-images]
     strategy:
       matrix:
         include:


### PR DESCRIPTION
This PR allows the cleanup playbook to be executed regardless if the deployment playbook finishes successfully or not. 

The playbooks are tested in persistent machines running in the cloud and when a deployment run doesn't finish successfully, the machine is left in an undetermined state that might affect the execution of the next CI run. This PR:
 - Separates the cleanup in a separate job to see more clearly if it executed correctly
 - Adds a continue-on-error: true to the deployment playbook so that the clean playbook still gets executed if it fails