### PR TITLE
Upgrade github actions runner ubuntu version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -83,6 +83,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Install ansible-core
+        run: sudo pipx install --force ansible-core==2.16.3
       - name: Install galaxy deps
         run: ansible-galaxy install -r requirements.yml
       - name: Run playbook

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ on:
 jobs:
   ansible-lint:
     name: Playbook linting
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
         with:
@@ -25,7 +25,7 @@ jobs:
 
   build-and-push-container-images:
     name: Build and push container images
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     if: github.event_name == 'release' || (github.event_name == 'push' && github.ref_name == 'main')
     needs: [ansible-lint, deploy-test-rpm]
     permissions:
@@ -66,7 +66,7 @@ jobs:
   deploy-test-rpm:
     name: Run the playbook on SLES 15 ${{ matrix.sp_version }}
     needs: [ansible-lint]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         include:
@@ -165,7 +165,7 @@ jobs:
             install_method='rpm'"
 
   create-artifact:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: [ansible-lint, deploy-test-rpm]
     steps:
       - uses: actions/checkout@v3
@@ -181,7 +181,7 @@ jobs:
             *.tgz
 
   release-rolling:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     if: (github.event_name == 'push' && github.ref == 'refs/heads/main')
     needs: [create-artifact]
     steps:
@@ -198,7 +198,7 @@ jobs:
             trento-ansible.tgz
 
   release:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     if: github.event.release
     needs: [create-artifact]
     steps:


### PR DESCRIPTION
# Description

Upgrade github actions runner ubuntu version.

Our ansible playbook is not supported beyond `ansible-core` 2.16. Above that, python3.6 is not supported in the agents.
We could try to change the playbook, but some packages like `py311-packaging` are missing in SLE15SP4.

https://github.com/actions/runner-images/issues/11101