### PR TITLE
Deploy checks in docker mode

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -124,7 +124,7 @@ jobs:
             nginx_ssl_key_as_base64='true' \
             nginx_ssl_cert='${{ secrets.SSL_CERT }}' \
             nginx_ssl_key='${{ secrets.SSL_KEY }}' \
-            install_method='rpm'"
+            install_method='docker'"
       - name: Test readiness
         run: curl -k "https://${{ env.TEST_HOST_IP }}/api/readyz"
       - name: Run playbook cleanup
@@ -164,7 +164,7 @@ jobs:
             nginx_ssl_key_as_base64='true' \
             nginx_ssl_cert='${{ secrets.SSL_CERT }}' \
             nginx_ssl_key='${{ secrets.SSL_KEY }}' \
-            install_method='rpm'"
+            install_method='docker'"
 
   create-artifact:
     runs-on: ubuntu-24.04

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -124,7 +124,7 @@ jobs:
             nginx_ssl_key_as_base64='true' \
             nginx_ssl_cert='${{ secrets.SSL_CERT }}' \
             nginx_ssl_key='${{ secrets.SSL_KEY }}' \
-            install_method='docker'"
+            install_method='rpm'"
       - name: Test readiness
         run: curl -k "https://${{ env.TEST_HOST_IP }}/api/readyz"
       - name: Run playbook cleanup
@@ -164,7 +164,7 @@ jobs:
             nginx_ssl_key_as_base64='true' \
             nginx_ssl_cert='${{ secrets.SSL_CERT }}' \
             nginx_ssl_key='${{ secrets.SSL_KEY }}' \
-            install_method='docker'"
+            install_method='rpm'"
 
   create-artifact:
     runs-on: ubuntu-24.04

--- a/README.md
+++ b/README.md
@@ -207,95 +207,99 @@ These variables are the defaults of our roles, if you want to override the prope
 
 **trento-server**
 
-| Name                           | Description                                                                                                      | Default                                     |
-| ------------------------------ | ---------------------------------------------------------------------------------------------------------------- | ------------------------------------------- |
-| provision_postgres             | Provision postgres role, set to false if you provide an external postgres to the services                        | "true"                                      |
-| provision_rabbitmq             | Provision rabbitmq role, set to false if you provide an external rabbitmq to the services                        | "true"                                      |
-| provision_proxy                | Provision nginx to expose the services, set to false to use an existing reverse proxy deployment                 | "true"                                      |
-| provision_prometheus           | Provision prometheus used by trento to store metrics send by agents                                              | "true"                                      |
-| docker_network_name            | Name of the docker network to be used by the deployment when using "docker" install_method                       | trentonet                                   |
-| web_container_image            | Name of the Web container image to use to create the container                                                   | ghcr.io/trento-project/trento-web:rolling   |
-| web_container_name             | Name of the Web container                                                                                        | trento_web                                  |
-| web_listen_port                | Port where the Web service is exposed                                                                            | 4000                                        |
-| wanda_container_image          | Name of the Wanda container image to use to create the container                                                 | ghcr.io/trento-project/trento-wanda:rolling |
-| wanda_container_name           | Name of the Wanda container                                                                                      | trento_wanda                                |
-| wanda_listen_port              | Port where the Wanda service is exposed                                                                          | 4001                                        |
-| force_pull_images              | Force pull the container images for trento components                                                            | false                                       |
-| force_recreate_web_container   | Recreate the web container                                                                                       | false                                       |
-| force_recreate_wanda_container | Recreate the wanda container                                                                                     | false                                       |
-| remove_web_container_image     | Remove Web container image in cleanup task                                                                       | true                                        |
-| remove_wanda_container_image   | Remove Wanda container image in cleanup task                                                                     | true                                        |
-| web_postgres_db                | Name of the postgres database of the web application                                                             | webdb                                       |
-| web_postgres_event_store       | Name of the postgres event store database of web application                                                     | event_store                                 |
-| web_postgres_user              | Name of the postgres user used by web application                                                                | web                                         |
-| install_postgres               | Install postgresql in the postgres provisioning phase                                                            | "true"                                      |
-| wanda_postgres_user            | Name of the postgres user used by wanda project                                                                  | wanda                                       |
-| wanda_postgres_db              | Name of the postgres database of wanda application                                                               | wanda                                       |
-| web_postgres_host              | Postgres host of web project container                                                                           | host.docker.internal                        |
-| wanda_postgres_host            | Postgres host of wanda project container                                                                         | host.docker.internal                        |
-| rabbitmq_vhost                 | The rabbitmq vhost used for the current deployment                                                               | trento                                      |
-| rabbitmq_username              | Username of rabbitmq user, this will be created by the rabbitmq role                                             | trento                                      |
-| rabbitmq_node_name             | The name of rabbitmq node                                                                                        | rabbit@localhost                            |
-| rabbitmq_host                  | The rabbitmq host, used by web and wanda containers. It could include the service port                           | host.docker.internal                        |
-| secret_key_base                | The secret of phoenix application                                                                                | Generated by playbook                       |
-| access_token_secret            | The secret used for access tokens JWT signature                                                                  | Generated by playbook                       |
-| refresh_token_secret           | The secret used for refresh tokens JWT signature                                                                 | Generated by playbook                       |
-| web_admin_username             | Username of the admin user in web application                                                                    | admin                                       |
-| enable_alerting                | Enable the alerting mechanism on web project                                                                     | false                                       |
-| alert_sender                   | Email address used as the "from" address in alerts                                                               |                                             |
-| alert_recipient                | Email address to receive alert notifications                                                                     |                                             |
-| smtp_server                    | IP address of the SMTP server                                                                                    |                                             |
-| smtp_port                      | Port number of SMTP server                                                                                       |                                             |
-| smtp_user                      | Username for SMTP authentication                                                                                 |                                             |
-| smtp_password                  | Password for SMTP authentication                                                                                 |                                             |
-| enable_oidc                    | Enable OIDC integration, this disables the username/password authentication method (self exclusive SSO type)     | false                                       |
-| oidc_client_id                 | OIDC client id, required when enable_oidc is true                                                                |                                             |
-| oidc_client_secret             | OIDC client secret, required when enable_oidc is true                                                            |                                             |
-| oidc_server_base_url           | OIDC identity provider base url, required when enable_oidc is true                                               |                                             |
-| enable_oauth2                  | Enable OAUTH2 integration, this disables the username/password authentication method (self exclusive SSO type)   | false                                       |
-| oauth2_client_id               | OAUTH2 client id, required when enable_oauth2 is true                                                            |                                             |
-| oauth2_client_secret           | OAUTH2 client secret, required when enable_oauth2 is true                                                        |                                             |
-| oauth2_server_base_url         | OAUTH2 identity provider base url, required when enable_oauth2 is true                                           |                                             |
-| oauth2_authorize_url           | OAUTH2 authorize url, required when enable_oauth2 is true                                                        |                                             |
-| oauth2_token_url               | OAUTH2 token url, required when enable_oauth2 is true                                                            |                                             |
-| oauth2_user_url                | OAUTH2 user information url, required when enable_oauth2 is true                                                 |                                             |
-| oauth2_scopes                  | OAUTH2 scopes, required when enable_oauth2 is true                                                               | "profile email"                             |
-| enable_saml                    | Enable SAML integration, this disables the username/password authentication method (self exclusive SSO type)     | false                                       |
-| saml_idp_id                    | SAML IDP id, required when enable_saml is true                                                                   |                                             |
-| saml_idp_nameid_format         | SAML IDP name id format, used to interpret the attribute name. Whole urn string must be used                     | urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified |
-| saml_sp_dir                    | SAML SP directory, where SP specific required files (such as certificates and metadata file) are placed          | /etc/trento/trento-web/saml                 |
-| saml_sp_id                     | SAML SP id, required when enable_saml is true                                                                    |                                             |
-| saml_sp_entity_id              | SAML SP entity id                                                                                                |                                             |
-| saml_sp_contact_name           | SAML SP contact name                                                                                             | "Trento SP Admin"                           |
-| saml_sp_contact_email          | SAML SP contact email                                                                                            | "admin@trento.suse.com"                     |
-| saml_sp_org_name               | SAML SP organization name                                                                                        | "Trento SP"                                 |
-| saml_sp_org_displayname        | SAML SP organization display name                                                                                | "SAML SP build with Trento"                 |
-| saml_sp_org_url                | SAML SP organization url                                                                                         | https://www.trento-project.io/              |
-| saml_username_attr_name        | SAML user profile "username" attribute field name. This attribute must exist in the IDP user                     | username                                    |
-| saml_email_attr_name           | SAML user profile "email" attribute field name. This attribute must exist in the IDP user                        | email                                       |
-| saml_firstname_attr_name       | SAML user profile "first name" attribute field name. This attribute must exist in the IDP user                   | firstName                                   |
-| saml_lastname_attr_name        | SAML user profile "last name" attribute field name. This attribute must exist in the IDP user                    | lastName                                    |
-| saml_metadata_url              | URL to retrieve the SAML metadata xml file. One of `saml_metadata_url` or `saml_metadata_content` is required    |                                             |
-| saml_metadata_content          | One line string containing the SAML metadata xml file content (`saml_metadata_url` has precedence over this)     |                                             |
-| saml_sign_requests             | Sign SAML requests in the SP side                                                                                | true                                        |
-| saml_sign_metadata             | Sign SAML metadata documents in the SP side                                                                      | true                                        |
-| saml_signed_assertion          | Require to receive SAML assertion signed from the IDP. Set to false if the IDP doesn't sign the assertion        | true                                        |
-| saml_signed_envelopes          | Require to receive SAML envelopes signed from the IDP. Set to false if the IDP doesn't sign the envelopes        | true                                        |
-| install_nginx                  | Install nginx                                                                                                    | true                                        |
-| nginx_ssl_cert_as_base64       | Nginx SSL certificate provided as base64 string                                                                  | false                                       |
-| nginx_ssl_key_as_base64        | Nginx SSL key provided as base64 string                                                                          | false                                       |
-| override_nginx_default_conf    | Override the default nginx conf for one that will use the vhosts according to an opinionated directory structure | true                                        |
-| nginx_vhost_filename           | Nginx vhost filename. "conf" suffix is added to the given name                                                   | trento                                      |
-| nginx_vhost_http_listen_port   | Configure the http listen port for trento (redirects to https by default)                                        | 80                                          |
-| nginx_vhost_https_listen_port  | Configure the https listen port for trento                                                                       | 443                                         |
-| enable_api_key                 | Enable/Disable API key usage. Mostly for testing purposes                                                        | true                                        |
-| enable_charts                  | Enable/Disable charts display based on Prometheus metrics                                                        | true                                        |
-| web_upstream_name              | Web nginx upstream name                                                                                          | web                                         |
-| wanda_upstream_name            | Wanda nginx upstream name                                                                                        | wanda                                       |
-| amqp_protocol                  | Change the amqp protocol type                                                                                    | amqp                                        |
-| prometheus_url                 | Prometheus server url                                                                                            | http://localhost:9090                       |
-| web_host                       | Host where the web instance is listening                                                                         | http://localhost                            |
-| install_method                 | Installation method for trento components, can be either `rpm` or `docker`                                       | rpm                                         |
+| Name                            | Description                                                                                                      | Default                                               |
+| ------------------------------- | ---------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
+| provision_postgres              | Provision postgres role, set to false if you provide an external postgres to the services                        | "true"                                                |
+| provision_rabbitmq              | Provision rabbitmq role, set to false if you provide an external rabbitmq to the services                        | "true"                                                |
+| provision_proxy                 | Provision nginx to expose the services, set to false to use an existing reverse proxy deployment                 | "true"                                                |
+| provision_prometheus            | Provision prometheus used by trento to store metrics send by agents                                              | "true"                                                |
+| docker_network_name             | Name of the docker network to be used by the deployment when using "docker" install_method                       | trentonet                                             |
+| web_container_image             | Name of the Web container image to use to create the container                                                   | ghcr.io/trento-project/trento-web:rolling             |
+| web_container_name              | Name of the Web container                                                                                        | trento_web                                            |
+| web_listen_port                 | Port where the Web service is exposed                                                                            | 4000                                                  |
+| wanda_container_image           | Name of the Wanda container image to use to create the container                                                 | ghcr.io/trento-project/trento-wanda:rolling           |
+| wanda_container_name            | Name of the Wanda container                                                                                      | trento_wanda                                          |
+| wanda_listen_port               | Port where the Wanda service is exposed                                                                          | 4001                                                  |
+| force_pull_images               | Force pull the container images for trento components                                                            | false                                                 |
+| force_recreate_web_container    | Recreate the web container                                                                                       | false                                                 |
+| force_recreate_wanda_container  | Recreate the wanda container                                                                                     | false                                                 |
+| remove_web_container_image      | Remove Web container image in cleanup task                                                                       | true                                                  |
+| remove_wanda_container_image    | Remove Wanda container image in cleanup task                                                                     | true                                                  |
+| checks_container_image          | Name of the Checks container image to use to create the container                                                | ghcr.io/trento-project/checks:rolling                 |
+| checks_container_name           | Name of the Checks container                                                                                     | trento_checks                                         |
+| force_recreate_checks_container | Recreate the checks container                                                                                    | false                                                 |
+| remove_checks_container_image   | Remove checks container image in cleanup task                                                                    | true                                                  |
+| web_postgres_db                 | Name of the postgres database of the web application                                                             | webdb                                                 |
+| web_postgres_event_store        | Name of the postgres event store database of web application                                                     | event_store                                           |
+| web_postgres_user               | Name of the postgres user used by web application                                                                | web                                                   |
+| install_postgres                | Install postgresql in the postgres provisioning phase                                                            | "true"                                                |
+| wanda_postgres_user             | Name of the postgres user used by wanda project                                                                  | wanda                                                 |
+| wanda_postgres_db               | Name of the postgres database of wanda application                                                               | wanda                                                 |
+| web_postgres_host               | Postgres host of web project container                                                                           | host.docker.internal                                  |
+| wanda_postgres_host             | Postgres host of wanda project container                                                                         | host.docker.internal                                  |
+| rabbitmq_vhost                  | The rabbitmq vhost used for the current deployment                                                               | trento                                                |
+| rabbitmq_username               | Username of rabbitmq user, this will be created by the rabbitmq role                                             | trento                                                |
+| rabbitmq_node_name              | The name of rabbitmq node                                                                                        | rabbit@localhost                                      |
+| rabbitmq_host                   | The rabbitmq host, used by web and wanda containers. It could include the service port                           | host.docker.internal                                  |
+| secret_key_base                 | The secret of phoenix application                                                                                | Generated by playbook                                 |
+| access_token_secret             | The secret used for access tokens JWT signature                                                                  | Generated by playbook                                 |
+| refresh_token_secret            | The secret used for refresh tokens JWT signature                                                                 | Generated by playbook                                 |
+| web_admin_username              | Username of the admin user in web application                                                                    | admin                                                 |
+| enable_alerting                 | Enable the alerting mechanism on web project                                                                     | false                                                 |
+| alert_sender                    | Email address used as the "from" address in alerts                                                               |                                                       |
+| alert_recipient                 | Email address to receive alert notifications                                                                     |                                                       |
+| smtp_server                     | IP address of the SMTP server                                                                                    |                                                       |
+| smtp_port                       | Port number of SMTP server                                                                                       |                                                       |
+| smtp_user                       | Username for SMTP authentication                                                                                 |                                                       |
+| smtp_password                   | Password for SMTP authentication                                                                                 |                                                       |
+| enable_oidc                     | Enable OIDC integration, this disables the username/password authentication method (self exclusive SSO type)     | false                                                 |
+| oidc_client_id                  | OIDC client id, required when enable_oidc is true                                                                |                                                       |
+| oidc_client_secret              | OIDC client secret, required when enable_oidc is true                                                            |                                                       |
+| oidc_server_base_url            | OIDC identity provider base url, required when enable_oidc is true                                               |                                                       |
+| enable_oauth2                   | Enable OAUTH2 integration, this disables the username/password authentication method (self exclusive SSO type)   | false                                                 |
+| oauth2_client_id                | OAUTH2 client id, required when enable_oauth2 is true                                                            |                                                       |
+| oauth2_client_secret            | OAUTH2 client secret, required when enable_oauth2 is true                                                        |                                                       |
+| oauth2_server_base_url          | OAUTH2 identity provider base url, required when enable_oauth2 is true                                           |                                                       |
+| oauth2_authorize_url            | OAUTH2 authorize url, required when enable_oauth2 is true                                                        |                                                       |
+| oauth2_token_url                | OAUTH2 token url, required when enable_oauth2 is true                                                            |                                                       |
+| oauth2_user_url                 | OAUTH2 user information url, required when enable_oauth2 is true                                                 |                                                       |
+| oauth2_scopes                   | OAUTH2 scopes, required when enable_oauth2 is true                                                               | "profile email"                                       |
+| enable_saml                     | Enable SAML integration, this disables the username/password authentication method (self exclusive SSO type)     | false                                                 |
+| saml_idp_id                     | SAML IDP id, required when enable_saml is true                                                                   |                                                       |
+| saml_idp_nameid_format          | SAML IDP name id format, used to interpret the attribute name. Whole urn string must be used                     | urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified |
+| saml_sp_dir                     | SAML SP directory, where SP specific required files (such as certificates and metadata file) are placed          | /etc/trento/trento-web/saml                           |
+| saml_sp_id                      | SAML SP id, required when enable_saml is true                                                                    |                                                       |
+| saml_sp_entity_id               | SAML SP entity id                                                                                                |                                                       |
+| saml_sp_contact_name            | SAML SP contact name                                                                                             | "Trento SP Admin"                                     |
+| saml_sp_contact_email           | SAML SP contact email                                                                                            | "admin@trento.suse.com"                               |
+| saml_sp_org_name                | SAML SP organization name                                                                                        | "Trento SP"                                           |
+| saml_sp_org_displayname         | SAML SP organization display name                                                                                | "SAML SP build with Trento"                           |
+| saml_sp_org_url                 | SAML SP organization url                                                                                         | https://www.trento-project.io/                        |
+| saml_username_attr_name         | SAML user profile "username" attribute field name. This attribute must exist in the IDP user                     | username                                              |
+| saml_email_attr_name            | SAML user profile "email" attribute field name. This attribute must exist in the IDP user                        | email                                                 |
+| saml_firstname_attr_name        | SAML user profile "first name" attribute field name. This attribute must exist in the IDP user                   | firstName                                             |
+| saml_lastname_attr_name         | SAML user profile "last name" attribute field name. This attribute must exist in the IDP user                    | lastName                                              |
+| saml_metadata_url               | URL to retrieve the SAML metadata xml file. One of `saml_metadata_url` or `saml_metadata_content` is required    |                                                       |
+| saml_metadata_content           | One line string containing the SAML metadata xml file content (`saml_metadata_url` has precedence over this)     |                                                       |
+| saml_sign_requests              | Sign SAML requests in the SP side                                                                                | true                                                  |
+| saml_sign_metadata              | Sign SAML metadata documents in the SP side                                                                      | true                                                  |
+| saml_signed_assertion           | Require to receive SAML assertion signed from the IDP. Set to false if the IDP doesn't sign the assertion        | true                                                  |
+| saml_signed_envelopes           | Require to receive SAML envelopes signed from the IDP. Set to false if the IDP doesn't sign the envelopes        | true                                                  |
+| install_nginx                   | Install nginx                                                                                                    | true                                                  |
+| nginx_ssl_cert_as_base64        | Nginx SSL certificate provided as base64 string                                                                  | false                                                 |
+| nginx_ssl_key_as_base64         | Nginx SSL key provided as base64 string                                                                          | false                                                 |
+| override_nginx_default_conf     | Override the default nginx conf for one that will use the vhosts according to an opinionated directory structure | true                                                  |
+| nginx_vhost_filename            | Nginx vhost filename. "conf" suffix is added to the given name                                                   | trento                                                |
+| nginx_vhost_http_listen_port    | Configure the http listen port for trento (redirects to https by default)                                        | 80                                                    |
+| nginx_vhost_https_listen_port   | Configure the https listen port for trento                                                                       | 443                                                   |
+| enable_api_key                  | Enable/Disable API key usage. Mostly for testing purposes                                                        | true                                                  |
+| enable_charts                   | Enable/Disable charts display based on Prometheus metrics                                                        | true                                                  |
+| web_upstream_name               | Web nginx upstream name                                                                                          | web                                                   |
+| wanda_upstream_name             | Wanda nginx upstream name                                                                                        | wanda                                                 |
+| amqp_protocol                   | Change the amqp protocol type                                                                                    | amqp                                                  |
+| prometheus_url                  | Prometheus server url                                                                                            | http://localhost:9090                                 |
+| web_host                        | Host where the web instance is listening                                                                         | http://localhost                                      |
+| install_method                  | Installation method for trento components, can be either `rpm` or `docker`                                       | rpm                                                   |
 
 
 **trento agents**

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This playbook aims to install Trento components and the belonging third parties.
 
 - [web](https://github.com/trento-project/web)
 - [wanda](https://github.com/trento-project/wanda)
+- [checks](https://github.com/trento-project/checks)
 - [agent](https://github.com/trento-project/agent)
 - postgresql
 - rabbitmq
@@ -22,7 +23,7 @@ This playbook aims to install Trento components and the belonging third parties.
 
 The third parties are installed using `zypper` packages and configured with dedicated roles. The
 `web` and `wanda` components can be installed using either docker or zypper. The playbook checks
-the `install_method` variable (either `docker` or `rpm`) to determine which to method to use.
+the `install_method` variable (either `docker` or `rpm`) to determine which method to use.
 
 The `agent` is installed from the configured obs repository using `zypper`.
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 FROM opensuse/leap:15
-LABEL org.opencontainers.image.source="https://github.com/CDimonaco/trento-ansible"
+LABEL org.opencontainers.image.source="https://github.com/trento-project/ansible"
 LABEL org.opencontainers.image.authors="Carmine Di Monaco <carmine.dimonaco@suse.com>"
 LABEL org.opencontainers.image.title="Trento Ansible"
 LABEL org.opencontainers.image.description="Ansible playbok for trento infrastructure deploy"

--- a/roles/app/defaults/docker.yml
+++ b/roles/app/defaults/docker.yml
@@ -11,5 +11,9 @@ wanda_container_name: trento_wanda
 force_recreate_wanda_container: "false"
 remove_wanda_container_image: "true"
 wanda_postgres_host: "host.docker.internal"
+checks_container_image: ghcr.io/trento-project/checks:rolling
+checks_container_name: trento_checks
+force_recreate_checks_container: "false"
+remove_checks_container_image: "true"
 rabbitmq_host: host.docker.internal
 prometheus_url: "http://host.docker.internal:9090"

--- a/roles/app/tasks/docker.yml
+++ b/roles/app/tasks/docker.yml
@@ -26,6 +26,7 @@
   loop:
     - "{{ wanda_container_image }}"
     - "{{ web_container_image }}"
+    - "{{ checks_container_image }}"
   community.docker.docker_image:
     name: "{{ item }}"
     force_source: true
@@ -34,6 +35,15 @@
 - name: Create trento docker network
   community.docker.docker_network:
     name: "{{ docker_network_name }}"
+
+- name: Checks container
+  community.docker.docker_container:
+    name: "{{ checks_container_name }}"
+    image: "{{ checks_container_image }}"
+    recreate: "{{ force_recreate_checks_container == 'true' }}"
+    pull: true
+    volumes:
+      - "/usr/share/trento/checks"
 
 - name: Wanda container
   community.docker.docker_container:
@@ -61,6 +71,8 @@
       ACCESS_TOKEN_ENC_SECRET: "{{ access_token_secret }}"
       AMQP_URL: "{{ amqp_protocol }}://{{ rabbitmq_username }}:{{ rabbitmq_password }}@{{ rabbitmq_host }}/{{ rabbitmq_vhost | urlencode | replace('/', '%2F') }}"
       DATABASE_URL: "ecto://{{ wanda_postgres_user }}:{{ wanda_postgres_password }}@{{ wanda_postgres_host }}/{{ wanda_postgres_db }}"
+    volumes_from:
+      - "{{ checks_container_name }}"
 
 - name: Web container
   community.docker.docker_container:

--- a/roles/app/tasks/docker.yml
+++ b/roles/app/tasks/docker.yml
@@ -72,7 +72,7 @@
       AMQP_URL: "{{ amqp_protocol }}://{{ rabbitmq_username }}:{{ rabbitmq_password }}@{{ rabbitmq_host }}/{{ rabbitmq_vhost | urlencode | replace('/', '%2F') }}"
       DATABASE_URL: "ecto://{{ wanda_postgres_user }}:{{ wanda_postgres_password }}@{{ wanda_postgres_host }}/{{ wanda_postgres_db }}"
     volumes_from:
-      - "{{ checks_container_name }}"
+      - "{{ checks_container_name }}:ro"
 
 - name: Web container
   community.docker.docker_container:

--- a/roles/app/tasks/docker_cleanup.yml
+++ b/roles/app/tasks/docker_cleanup.yml
@@ -21,6 +21,12 @@
     state: absent
     name: "{{ wanda_container_image }}"
 
+- name: Remove checks container image
+  when: remove_checks_container_image == 'true'
+  community.docker.docker_image:
+    state: absent
+    name: "{{ checks_container_image }}"
+
 - name: Remove web container image
   when: remove_web_container_image == 'true'
   community.docker.docker_image:

--- a/roles/app/tasks/docker_cleanup.yml
+++ b/roles/app/tasks/docker_cleanup.yml
@@ -15,6 +15,12 @@
     state: absent
     keep_volumes: false
 
+- name: Stop checks container
+  community.docker.docker_container:
+    name: "{{ checks_container_name }}"
+    state: absent
+    keep_volumes: false
+
 - name: Remove wanda container image
   when: remove_wanda_container_image == 'true'
   community.docker.docker_image:


### PR DESCRIPTION
Add missing checks during a docker based installation.

Note: the pipeline currently tests the playbook in rpm mode, and it would be great testing also the docker mode.
Options are:
- after the rpm test we run docker tests on the same machines, meaning the pipeline would take longer
- we have a set of other 3 machines to concurrently test also docker installation

Open for suggestions.