### PR TITLE
Use underscores in inventory host groups

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -99,15 +99,15 @@ jobs:
                 ansible_user: ${{ secrets.TEST_HOST_USER }}
                 ansible_python_interpreter: /usr/bin/python3
               children:
-                trento-server:
+                trento_server:
                   hosts:
                     server:
                       ansible_host: ${{ env.TEST_HOST_IP }}
-                postgres-hosts:
+                postgres_hosts:
                   hosts:
                     server:
                       ansible_host: ${{ env.TEST_HOST_IP }}
-                rabbitmq-hosts:
+                rabbitmq_hosts:
                   hosts:
                     server:
                       ansible_host: ${{ env.TEST_HOST_IP }}
@@ -139,15 +139,15 @@ jobs:
                 ansible_user: ${{ secrets.TEST_HOST_USER }}
                 ansible_python_interpreter: /usr/bin/python3
               children:
-                trento-server:
+                trento_server:
                   hosts:
                     server:
                       ansible_host: ${{ env.TEST_HOST_IP }}
-                postgres-hosts:
+                postgres_hosts:
                   hosts:
                     server:
                       ansible_host: ${{ env.TEST_HOST_IP }}
-                rabbitmq-hosts:
+                rabbitmq_hosts:
                   hosts:
                     server:
                       ansible_host: ${{ env.TEST_HOST_IP }}

--- a/README.md
+++ b/README.md
@@ -60,16 +60,16 @@ than one role. Use `;` to comment out any role that you might not want to cover.
 Example:
 
 ```
-[trento-server]
+[trento_server]
 192.168.1.1 ansible_user=root ansible_ssh_private_key_file=/home/user/.ssh/id_rsa
 
-[postgres-hosts]
+[postgres_hosts]
 192.168.1.1 ansible_user=root ansible_ssh_private_key_file=/home/user/.ssh/id_rsa
 
-[rabbitmq-hosts]
+[rabbitmq_hosts]
 192.168.1.1 ansible_user=root ansible_ssh_private_key_file=/home/user/.ssh/id_rsa
 
-[prometheus-hosts]
+[prometheus_hosts]
 192.168.1.1 ansible_user=root ansible_ssh_private_key_file=/home/user/.ssh/id_rsa
 
 ; [agents]
@@ -81,22 +81,22 @@ Alternatively, you can use yaml syntax for this. In the following example we use
 ```yaml
 all:
   children:
-    trento-server:
+    trento_server:
       hosts:
         vitellone:
           ansible_host: "your-host"
           ansible_user: "your-user"
-    postgres-hosts:
+    postgres_hosts:
       hosts:
         vitellone:
           ansible_host: "your-host"
           ansible_user: "your-user"
-    rabbitmq-hosts:
+    rabbitmq_hosts:
       hosts:
         vitellone:
           ansible_host: "your-host"
           ansible_user: "your-user"
-    prometheus-hosts:
+    prometheus_hosts:
       hosts:
         vitellone:
           ansible_host: "your-host"
@@ -148,7 +148,7 @@ ansible-playbook -i path/to/inventory.yml --extra-vars "@path/to/vars.json" play
 ```
 
 
-Both trento-server and agent inventory and variables file can be combined to deploy both at the same ansible execution.
+Both trento_server and agent inventory and variables file can be combined to deploy both at the same ansible execution.
 
 Having an inventory file called `inventory.yml` and a vars file called `extra-vars.json`, you could run the playbook
 
@@ -178,7 +178,7 @@ Assuming you have in the current folder a file called `inventory.yml` and `extra
 
 ## Playbook variables
 
-### Required Variables to install trento-server
+### Required Variables to install trento_server
 
 | Name                    | Description                                                               |
 | ----------------------- | ------------------------------------------------------------------------- |
@@ -195,7 +195,7 @@ Assuming you have in the current folder a file called `inventory.yml` and `extra
 
 | Name              | Description                                                      |
 | ----------------- | ---------------------------------------------------------------- |
-| trento_api_key    | API key to connect to the trento-server                          |
+| trento_api_key    | API key to connect to the trento_server                          |
 | rabbitmq_password | Password of the rabbitmq user configured for the trento projects |
 
 ### Optional variables

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,10 +7,10 @@ Vagrant.configure(2) do |config|
   config.vm.provision "ansible" do |ansible|
     ansible.playbook = "playbook.yml"
     ansible.groups = {
-      "trento-server" => ["machine1"],
-      "postgres-hosts" => ["machine1"],
-      "prometheus-hosts" => ["machine1"],
-      "rabbitmq-hosts" => ["machine1"]
+      "trento_server" => ["machine1"],
+      "postgres_hosts" => ["machine1"],
+      "prometheus_hosts" => ["machine1"],
+      "rabbitmq_hosts" => ["machine1"]
     }
     ansible.extra_vars = {
       web_postgres_password: "pass",

--- a/examples/dedicated-nodes/README.md
+++ b/examples/dedicated-nodes/README.md
@@ -1,5 +1,5 @@
 This example portrays a configuration where all nodes are deployed on different machines. In this deployment:
- - `vitellone` is the hostname where `trento-server` gets deployed
+ - `vitellone` is the hostname where `trento_server` gets deployed
  - `vitellone-pg` is where `postgres` gets deployed
  - `vitellone-mq` is where `rabbitmq` gets deployed
  - `vitellone-metrics` is where `prometheus` gets deployed

--- a/examples/dedicated-nodes/inventory.yml
+++ b/examples/dedicated-nodes/inventory.yml
@@ -1,21 +1,21 @@
 all:
   children:
-    trento-server:
+    trento_server:
       hosts:
         vitellone:
           ansible_host: "your-host"
           ansible_user: "your-user"
-    postgres-hosts:
+    postgres_hosts:
       hosts:
         vitellone-pg:
           ansible_host: "your-host"
           ansible_user: "your-user"
-    rabbitmq-hosts:
+    rabbitmq_hosts:
       hosts:
         vitellone-mq:
           ansible_host: "your-host"
           ansible_user: "your-user"
-    prometheus-hosts:
+    prometheus_hosts:
       hosts:
         vitellone-metrics:
           ansible_host: "your-host"

--- a/examples/external-services/README.md
+++ b/examples/external-services/README.md
@@ -1,3 +1,3 @@
-This example portrays a configuration where only `trento-server` is deployed, while the configuration points to external services outside of the 
+This example portrays a configuration where only `trento_server` is deployed, while the configuration points to external services outside of the 
 scope of this playbook. In this deployment:
- - `vitellone` is the hostname where `trento-server` gets deployed
+ - `vitellone` is the hostname where `trento_server` gets deployed

--- a/examples/external-services/inventory.yml
+++ b/examples/external-services/inventory.yml
@@ -1,6 +1,6 @@
 all:
   children:
-    trento-server:
+    trento_server:
       hosts:
         vitellone:
           ansible_host: "your-host"

--- a/examples/single-node/README.md
+++ b/examples/single-node/README.md
@@ -1,5 +1,5 @@
 This example portrays a single-node configuration, where all nodes are deployed on the same machine. In this deployment:
- - `vitellone` is the hostname where `trento-server` gets deployed
+ - `vitellone` is the hostname where `trento_server` gets deployed
 
 Agent nodes are *not* deployed with this configuration.
 

--- a/examples/single-node/inventory.yml
+++ b/examples/single-node/inventory.yml
@@ -1,21 +1,21 @@
 all:
   children:
-    trento-server:
+    trento_server:
       hosts:
         vitellone:
           ansible_host: "your-host"
           ansible_user: "your-user"
-    postgres-hosts:
+    postgres_hosts:
       hosts:
         vitellone:
           ansible_host: "your-host"
           ansible_user: "your-user"
-    rabbitmq-hosts:
+    rabbitmq_hosts:
       hosts:
         vitellone:
           ansible_host: "your-host"
           ansible_user: "your-user"
-    prometheus-hosts:
+    prometheus_hosts:
       hosts:
         vitellone:
           ansible_host: "your-host"

--- a/playbook.cleanup.yml
+++ b/playbook.cleanup.yml
@@ -1,7 +1,7 @@
 # code: language=ansible
 ---
-- name: Check firewalld package on prometheus and trento-server hosts
-  hosts: prometheus-hosts:trento-server
+- name: Check firewalld package on prometheus and trento_server hosts
+  hosts: prometheus_hosts:trento_server
   tasks:
     - name: Collect package facts
       ansible.builtin.package_facts:
@@ -15,7 +15,7 @@
       register: firewalld_status
 
 - name: Clean up trento components
-  hosts: trento-server
+  hosts: trento_server
   become: true
   tasks:
     - name: Trento services
@@ -28,7 +28,7 @@
         tasks_from: cleanup
 
 - name: Clean up postgres
-  hosts: postgres-hosts
+  hosts: postgres_hosts
   become: true
   tasks:
     - name: Postgres
@@ -37,7 +37,7 @@
         tasks_from: cleanup
 
 - name: Clean up rabbitmq
-  hosts: rabbitmq-hosts
+  hosts: rabbitmq_hosts
   become: true
   tasks:
     - name: Rabbitmq
@@ -46,7 +46,7 @@
         tasks_from: cleanup
 
 - name: Prometheus cleanup
-  hosts: prometheus-hosts
+  hosts: prometheus_hosts
   become: true
   tasks:
     - name: Prometheus

--- a/playbook.yml
+++ b/playbook.yml
@@ -1,7 +1,7 @@
 # code: language=ansible
 ---
 - name: Install thirdparties
-  hosts: trento-server
+  hosts: trento_server
   become: true
   pre_tasks:
     - name: Check SLES distribution and version
@@ -30,8 +30,8 @@
         state: present
         update_cache: true
 
-- name: Check firewalld package on prometheus and trento-server hosts
-  hosts: prometheus-hosts:trento-server
+- name: Check firewalld package on prometheus and trento_server hosts
+  hosts: prometheus_hosts:trento_server
   tasks:
     - name: Collect package facts
       ansible.builtin.package_facts:
@@ -52,7 +52,7 @@
   become: true
   vars:
     provision_postgres: "true"
-  hosts: postgres-hosts
+  hosts: postgres_hosts
   roles:
     - role: postgres
       when: provision_postgres == 'true'
@@ -62,7 +62,7 @@
   become: true
   vars:
     provision_prometheus: "true"
-  hosts: prometheus-hosts
+  hosts: prometheus_hosts
   roles:
     - role: prometheus
       when: provision_prometheus == 'true'
@@ -72,7 +72,7 @@
   become: true
   vars:
     provision_rabbitmq: "true"
-  hosts: rabbitmq-hosts
+  hosts: rabbitmq_hosts
   roles:
     - role: rabbitmq
       when: provision_rabbitmq == 'true'
@@ -80,7 +80,7 @@
 - name: Configure trento components
   vars:
     provision_proxy: "true"
-  hosts: trento-server
+  hosts: trento_server
   become: true
   roles:
     - role: app


### PR DESCRIPTION
As per the [Ansible docs](https://docs.ansible.com/ansible/latest/network/getting_started/first_inventory.html):

> Avoid spaces, hyphens, and preceding numbers (use floor_19, not 19th_floor) in your group names. Group names are case sensitive.

This PR replaces every `-` with `_` in inventory group names. These changes have no functional effect but increase the portability of the playbook (some Ansible installation are less permissive and may reject the inventory).