### PR TITLE
Updated ansible linter in the CI to v25

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,3 +1,4 @@
+---
 exclude_paths:
   - .github/
 skip_list:

--- a/.ansible-lint
+++ b/.ansible-lint
@@ -2,5 +2,4 @@
 exclude_paths:
   - .github/
 skip_list:
-  - var-naming[no-role-prefix]
   - yaml[line-length]

--- a/.ansible-lint
+++ b/.ansible-lint
@@ -2,4 +2,5 @@
 exclude_paths:
   - .github/
 skip_list:
+  - var-naming[no-role-prefix]
   - yaml[line-length]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,6 +22,8 @@ jobs:
 
       - name: Run ansible-lint
         uses: ansible/ansible-lint@v25
+        with:
+          args: "-x no-role-prefix"
 
   build-and-push-container-images:
     name: Build and push container images

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
           fetch-depth: 0
 
       - name: Run ansible-lint
-        uses: ansible/ansible-lint-action@v25
+        uses: ansible/ansible-lint@v25
 
   build-and-push-container-images:
     name: Build and push container images

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
           fetch-depth: 0
 
       - name: Run ansible-lint
-        uses: ansible/ansible-lint-action@v6
+        uses: ansible/ansible-lint-action@v25
 
   build-and-push-container-images:
     name: Build and push container images

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,8 +22,6 @@ jobs:
 
       - name: Run ansible-lint
         uses: ansible/ansible-lint@v25
-        with:
-          args: "-x no-role-prefix"
 
   build-and-push-container-images:
     name: Build and push container images

--- a/.yamllint
+++ b/.yamllint
@@ -1,3 +1,4 @@
+---
 rules:
   indentation:
     spaces: 2

--- a/examples/dedicated-nodes/inventory.yml
+++ b/examples/dedicated-nodes/inventory.yml
@@ -1,3 +1,4 @@
+---
 all:
   children:
     trento_server:

--- a/examples/external-services/inventory.yml
+++ b/examples/external-services/inventory.yml
@@ -1,3 +1,4 @@
+---
 all:
   children:
     trento_server:

--- a/examples/install-agents/inventory.yml
+++ b/examples/install-agents/inventory.yml
@@ -1,3 +1,4 @@
+---
 all:
   children:
     agents:

--- a/examples/single-node/inventory.yml
+++ b/examples/single-node/inventory.yml
@@ -1,3 +1,4 @@
+---
 all:
   children:
     trento_server:

--- a/roles/postgres/defaults/main.yml
+++ b/roles/postgres/defaults/main.yml
@@ -1,3 +1,4 @@
+---
 web_postgres_db: webdb
 web_postgres_event_store: event_store
 web_postgres_user: web

--- a/roles/postgres/tasks/cleanup.yml
+++ b/roles/postgres/tasks/cleanup.yml
@@ -1,31 +1,30 @@
 # code: language=ansible
 ---
-- name: Remove web database
+- name: Cleanup Postgres installation
+  become: true
   become_user: postgres
-  community.postgresql.postgresql_db:
-    name: "{{ web_postgres_db }}"
-    state: absent
+  block:
+    - name: Remove web database
+      community.postgresql.postgresql_db:
+        name: "{{ web_postgres_db }}"
+        state: absent
 
-- name: Remove web event store database
-  become_user: postgres
-  community.postgresql.postgresql_db:
-    name: "{{ web_postgres_event_store }}"
-    state: absent
+    - name: Remove web event store database
+      community.postgresql.postgresql_db:
+        name: "{{ web_postgres_event_store }}"
+        state: absent
 
-- name: Remove wanda event store database
-  become_user: postgres
-  community.postgresql.postgresql_db:
-    name: "{{ wanda_postgres_db }}"
-    state: absent
+    - name: Remove wanda event store database
+      community.postgresql.postgresql_db:
+        name: "{{ wanda_postgres_db }}"
+        state: absent
 
-- name: Remove web database user
-  become_user: postgres
-  community.postgresql.postgresql_user:
-    name: "{{ web_postgres_user }}"
-    state: absent
+    - name: Remove web database user
+      community.postgresql.postgresql_user:
+        name: "{{ web_postgres_user }}"
+        state: absent
 
-- name: Remove wanda database user
-  become_user: postgres
-  community.postgresql.postgresql_user:
-    name: "{{ wanda_postgres_user }}"
-    state: absent
+    - name: Remove wanda database user
+      community.postgresql.postgresql_user:
+        name: "{{ wanda_postgres_user }}"
+        state: absent

--- a/roles/postgres/tasks/main.yml
+++ b/roles/postgres/tasks/main.yml
@@ -10,7 +10,6 @@
     state: present
     update_cache: true
 
-
 - name: Install postgresql-server-devel manually using expect module
   ansible.builtin.expect:
     command: zypper install postgresql15-server-devel
@@ -31,88 +30,82 @@
     state: started
     enabled: true
 
-- name: "Configure postgres to listen on *"
+- name: Configure Postgres
+  become: true
   become_user: postgres
-  community.postgresql.postgresql_set:
-    name: listen_addresses
-    value: "*"
-  notify: Restart postgres
+  block:
+    - name: "Configure postgres to listen on *"
+      community.postgresql.postgresql_set:
+        name: listen_addresses
+        value: "*"
+      notify: Restart postgres
 
-# this task is implemented with `lineinfile` instead of `pg_hba` module
-# as the second want does not provide any option to set the order of
-# the new entry, and this case, the new entry must be pretty much on top
-# of the host entries to apply properly the precedence of rules
-- name: Configure pg_hba to accept connection from trento services
-  become_user: postgres
-  notify: Restart postgres
-  ansible.builtin.lineinfile:
-    path: /var/lib/pgsql/data/pg_hba.conf
-    regexp: "^host.*{{ web_postgres_db }},{{ web_postgres_event_store }},{{ wanda_postgres_db }}"
-    insertafter: "^local.*all.*all.*peer"
-    line: "host\t{{ web_postgres_db }},{{ web_postgres_event_store }},{{ wanda_postgres_db }}\t{{ web_postgres_user }},{{ wanda_postgres_user }}\t0.0.0.0/0\tmd5"
+    # this task is implemented with `lineinfile` instead of `pg_hba` module
+    # as the second want does not provide any option to set the order of
+    # the new entry, and this case, the new entry must be pretty much on top
+    # of the host entries to apply properly the precedence of rules
+    - name: Configure pg_hba to accept connection from trento services
+      notify: Restart postgres
+      ansible.builtin.lineinfile:
+        path: /var/lib/pgsql/data/pg_hba.conf
+        regexp: "^host.*{{ web_postgres_db }},{{ web_postgres_event_store }},{{ wanda_postgres_db }}"
+        insertafter: "^local.*all.*all.*peer"
+        line: "host\t{{ web_postgres_db }},{{ web_postgres_event_store }},{{ wanda_postgres_db }}\t{{ web_postgres_user }},{{ wanda_postgres_user }}\t0.0.0.0/0\tmd5"
 
-- name: Create postgres web database
-  become_user: postgres
-  community.postgresql.postgresql_db:
-    name: "{{ web_postgres_db }}"
-    state: present
+    - name: Create postgres web database
+      community.postgresql.postgresql_db:
+        name: "{{ web_postgres_db }}"
+        state: present
 
-- name: Create postgres web event store
-  become_user: postgres
-  community.postgresql.postgresql_db:
-    name: "{{ web_postgres_event_store }}"
-    state: present
+    - name: Create postgres web event store
+      community.postgresql.postgresql_db:
+        name: "{{ web_postgres_event_store }}"
+        state: present
 
-- name: Create postgres wanda database
-  become_user: postgres
-  community.postgresql.postgresql_db:
-    name: "{{ wanda_postgres_db }}"
-    state: present
+    - name: Create postgres wanda database
+      community.postgresql.postgresql_db:
+        name: "{{ wanda_postgres_db }}"
+        state: present
 
-- name: Create web database user
-  become_user: postgres
-  community.postgresql.postgresql_user:
-    db: "{{ web_postgres_db }}"
-    name: "{{ web_postgres_user }}"
-    password: "{{ web_postgres_password }}"
-    comment: "Web user provisioned by playbook"
-    state: present
+    - name: Create web database user
+      community.postgresql.postgresql_user:
+        db: "{{ web_postgres_db }}"
+        name: "{{ web_postgres_user }}"
+        password: "{{ web_postgres_password }}"
+        comment: "Web user provisioned by playbook"
+        state: present
 
-- name: Create wanda database user
-  become_user: postgres
-  community.postgresql.postgresql_user:
-    db: "{{ wanda_postgres_db }}"
-    name: "{{ wanda_postgres_user }}"
-    password: "{{ wanda_postgres_password }}"
-    comment: "Wanda user provisioned by playbook"
-    state: present
+    - name: Create wanda database user
+      community.postgresql.postgresql_user:
+        db: "{{ wanda_postgres_db }}"
+        name: "{{ wanda_postgres_user }}"
+        password: "{{ wanda_postgres_password }}"
+        comment: "Wanda user provisioned by playbook"
+        state: present
 
-- name: Grant privilegies to the web user for the web database
-  become_user: postgres
-  community.postgresql.postgresql_privs:
-    db: "{{ web_postgres_db }}"
-    objs: public
-    roles: "{{ web_postgres_user }}"
-    privs: ALL
-    type: schema
-    state: present
+    - name: Grant privilegies to the web user for the web database
+      community.postgresql.postgresql_privs:
+        db: "{{ web_postgres_db }}"
+        objs: public
+        roles: "{{ web_postgres_user }}"
+        privs: ALL
+        type: schema
+        state: present
 
-- name: Grant privilegies to the web user for the web event store
-  become_user: postgres
-  community.postgresql.postgresql_privs:
-    db: "{{ web_postgres_event_store }}"
-    objs: public
-    roles: "{{ web_postgres_user }}"
-    privs: ALL
-    type: schema
-    state: present
+    - name: Grant privilegies to the web user for the web event store
+      community.postgresql.postgresql_privs:
+        db: "{{ web_postgres_event_store }}"
+        objs: public
+        roles: "{{ web_postgres_user }}"
+        privs: ALL
+        type: schema
+        state: present
 
-- name: Grant privilegies to the wanda user for the wanda database
-  become_user: postgres
-  community.postgresql.postgresql_privs:
-    db: "{{ wanda_postgres_db }}"
-    objs: public
-    roles: "{{ wanda_postgres_user }}"
-    privs: ALL
-    type: schema
-    state: present
+    - name: Grant privilegies to the wanda user for the wanda database
+      community.postgresql.postgresql_privs:
+        db: "{{ wanda_postgres_db }}"
+        objs: public
+        roles: "{{ wanda_postgres_user }}"
+        privs: ALL
+        type: schema
+        state: present

--- a/roles/postgres/vars/main.yml
+++ b/roles/postgres/vars/main.yml
@@ -1,1 +1,2 @@
+---
 ansible_ssh_pipelining: true

--- a/roles/prometheus/defaults/main.yml
+++ b/roles/prometheus/defaults/main.yml
@@ -1,3 +1,4 @@
+---
 prometheus_port: 9090
 web_host: http://localhost
 web_listen_port: "{{ 32767 | random(start=1024, seed=trento_server_name) }}"


### PR DESCRIPTION
Update the ansible-linter action in the CI to the latest version of v25.

To accomodate the new rules:
- In Postgres role fixed `partial_become` definitions by combining `become` and `become_user` together in task block. Moved the previously independent tasks under the newly created task groups.
- Added `---` marker to all yaml files that were missing it;
- Added var-naming[no-role-prefix] as exception rule in the linter, temporarily to not block progress on the repository. 

The `no-role-prefix` would be removed once gradually fixing all the places it is encountered. This will involve a backwards-compatibility and alot of changes, so will be addressed in separete PR.
