### PR TITLE
[TRNT-4317] Pin GHA to SHA instead of tags

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,20 +18,20 @@ jobs:
     name: Playbook linting
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
           ssh-key: ${{ secrets.TRENTOBOT_SSH_KEY }}
 
       - name: Run ansible-lint on main playbook
-        uses: ansible/ansible-lint@v25
+        uses: ansible/ansible-lint@a2bc8b8b13a80802215856c56823d85007d3baf5 # v25
 
       - name: List available collections
         run: |
           ansible-galaxy collection list
 
       - name: Run ansible-lint on devbox playbook
-        uses: ansible/ansible-lint@v25
+        uses: ansible/ansible-lint@a2bc8b8b13a80802215856c56823d85007d3baf5 # v25
         with:
           setup_python: false
           working_directory: "./devbox/ansible"
@@ -78,7 +78,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
           ssh-key: ${{ secrets.TRENTOBOT_SSH_KEY }}
@@ -91,7 +91,7 @@ jobs:
 
       - name: Run playbook
         id: runplaybook
-        uses: dawidd6/action-ansible-playbook@v2
+        uses: dawidd6/action-ansible-playbook@c97d71562fcba83cc1ea0602d5a77013427f7571 # v2
         with:
           playbook: playbook.yml
           key: ${{ secrets.SSH_MACHINE_KEY }}
@@ -146,7 +146,7 @@ jobs:
         run: curl -k "https://${{ env.TEST_HOST_IP }}/api/readyz"
 
       - name: Run playbook cleanup
-        uses: dawidd6/action-ansible-playbook@v2
+        uses: dawidd6/action-ansible-playbook@c97d71562fcba83cc1ea0602d5a77013427f7571 # v2
         if: success() || steps.runplaybook.conclusion == 'failure'
         with:
           playbook: playbook.cleanup.yml

--- a/.github/workflows/git-release.yaml
+++ b/.github/workflows/git-release.yaml
@@ -37,7 +37,7 @@ jobs:
       version: ${{ steps.detect-version.outputs.current-version }}
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 2        # required by detect-version step
           ref: ${{ inputs.triggering_branch }}
@@ -45,7 +45,7 @@ jobs:
 
       - name: Detect new version
         id: detect-version
-        uses: salsify/action-detect-and-tag-new-version@v2
+        uses: salsify/action-detect-and-tag-new-version@b1778166f13188a9d478e2d1198f993011ba9864 # v2.0.3
         with:
           create-tag: false
           # Test for file existence protects against failing when
@@ -56,7 +56,7 @@ jobs:
 
       - name: Draft release
         id: draft-release
-        uses: release-drafter/release-drafter@v6
+        uses: release-drafter/release-drafter@6a93d829887aa2e0748befe2e808c66c0ec6e4c7 # v6
         with:
           config-name: release_drafter_${{ inputs.triggering_branch }}.yaml
           publish: false
@@ -67,14 +67,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.gh_token }}
 
       - name: Update CHANGELOG.md
-        uses: stefanzweifel/changelog-updater-action@v1
+        uses: stefanzweifel/changelog-updater-action@a938690fad7edf25368f37e43a1ed1b34303eb36 # v1
         with:
           latest-version: ${{ steps.detect-version.outputs.current-version }}
           release-notes: ${{ steps.draft-release.outputs.body }}
 
       - name: Import GPG key
         id: import-gpg
-        uses: crazy-max/ghaction-import-gpg@v7
+        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7
         with:
           gpg_private_key: ${{ secrets.gpg_key }}
           git_user_signingkey: true
@@ -82,7 +82,7 @@ jobs:
           git_tag_gpgsign: true
 
       - name: Commit new changelog
-        uses: stefanzweifel/git-auto-commit-action@v7
+        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7
         with:
           # We need to checkout `branch` explicitly because
           # `detect-version` messes with the HEAD ref.
@@ -104,7 +104,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
           ref: main
@@ -112,7 +112,7 @@ jobs:
 
       - name: Import GPG key
         id: import-gpg
-        uses: crazy-max/ghaction-import-gpg@v7
+        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7
         with:
           gpg_private_key: ${{ secrets.gpg_key }}
           git_user_signingkey: true
@@ -149,7 +149,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
           ref: release
@@ -157,7 +157,7 @@ jobs:
 
       - name: Import GPG key
         id: import-gpg
-        uses: crazy-max/ghaction-import-gpg@v7
+        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7
         with:
           gpg_private_key: ${{ secrets.gpg_key }}
           git_user_signingkey: true
@@ -193,7 +193,7 @@ jobs:
     steps:
       - name: Publish release
         id: publish-release
-        uses: release-drafter/release-drafter@v6
+        uses: release-drafter/release-drafter@6a93d829887aa2e0748befe2e808c66c0ec6e4c7 # v6
         with:
           config-name: release_drafter_${{ inputs.triggering_branch }}.yaml
           publish: true

--- a/.github/workflows/publish-containers.yaml
+++ b/.github/workflows/publish-containers.yaml
@@ -57,7 +57,7 @@ jobs:
       - name: Configure git for in-container operations
         run: git config --global --add safe.directory $GITHUB_WORKSPACE
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
           ref: ${{ inputs.branch }}
@@ -76,13 +76,13 @@ jobs:
     env:
       IMAGE_REPOSITORY: ${{ inputs.registry }}/${{ github.repository_owner }}/${{ inputs.image_name }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
           ref: ${{ inputs.branch }}
           ssh-key: ${{ secrets.ssh_key }}
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log into the Container registry
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef
@@ -98,7 +98,7 @@ jobs:
           images: ${{ env.IMAGE_REPOSITORY }}
 
       - name: Build and push container image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: ${{ inputs.dockerfile }}


### PR DESCRIPTION
# Description

As security incidents are popping up constantly, it is a good practice to pin the GHA to a specific SHA instead of tags, in case the GHA repository gets compromised. This PR replaces all the versions with the specific SHA.

Related # TRNT-4317


```
==> Summary
    Total uses: references found : 28
    Already pinned (SHA)         : 2
    Pinned in this run           : 21
    Resolved from cache          : 16
    Hardcoded overrides applied  : 0
    Private/inaccessible (logged): 0
    Failed to resolve            : 0
```

## How was this tested?

N/A