### PR TITLE
[TRNT-4358] Add license headers

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,6 +25,9 @@ jobs:
           fetch-depth: 0
           ssh-key: ${{ secrets.TRENTOBOT_SSH_KEY }}
 
+      - uses: apache/skywalking-eyes/header@61275cc80d0798a405cb070f7d3a8aaf7cf2c2c1 # v0.8.0
+        name: Check license headers
+
       - name: Run ansible-lint on main playbook
         uses: ansible/ansible-lint@a2bc8b8b13a80802215856c56823d85007d3baf5 # v25
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 name: CI
 
 on:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 name: Release
 
 on:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 # Created by https://www.toptal.com/developers/gitignore/api/python,ansible,vagrant
 # Edit at https://www.toptal.com/developers/gitignore?templates=python,ansible,vagrant
 

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
+header:
+  comment: on-failure
+  license:
+    spdx-id: Apache-2.0
+    copyright-owner: SUSE LLC
+    software-name: ansible-trento
+    content: |
+      SPDX-FileCopyrightText: SUSE LLC
+      SPDX-License-Identifier: Apache-2.0
+  paths-ignore:
+    - "**/*.adoc"
+    - "**/*.md"
+    - ".ansible-lint"
+    - ".ansible-lint-ignore"
+    - ".github/dependabot.yml"
+    - ".tool-versions"
+    - ".yamllint"
+    - "LICENSE"
+    - "VERSION"
+    - "inventory"

--- a/.obs/workflows.yml
+++ b/.obs/workflows.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 rolling_release:
   steps:
     - trigger_services:

--- a/agent.yml
+++ b/agent.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 - name: Provision Trento agents
   hosts: agents

--- a/cleanup-agents.yml
+++ b/cleanup-agents.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 # code: language=ansible
 ---
 - name: Clean up trento components

--- a/cleanup.yml
+++ b/cleanup.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 # code: language=ansible
 ---
 - name: Clean up trento components

--- a/devbox/ansible/ansible.cfg
+++ b/devbox/ansible/ansible.cfg
@@ -1,3 +1,6 @@
+; SPDX-FileCopyrightText: SUSE LLC
+; SPDX-License-Identifier: Apache-2.0
+
 [defaults]
 nocows = True
 roles_path = ./roles

--- a/devbox/ansible/inventory/devboxes.kubevirt.yml
+++ b/devbox/ansible/inventory/devboxes.kubevirt.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 plugin: kubevirt.core.kubevirt
 name: devboxes

--- a/devbox/ansible/inventory/inventory.sample.yml
+++ b/devbox/ansible/inventory/inventory.sample.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 k3s_servers:
   hosts:

--- a/devbox/ansible/playbooks/deploy_devbox.yml
+++ b/devbox/ansible/playbooks/deploy_devbox.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 - name: Setup k3s cluster
   hosts: k3s_servers

--- a/devbox/ansible/playbooks/test_trento_playbook.yml
+++ b/devbox/ansible/playbooks/test_trento_playbook.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 - name: Deploy devbox
   ansible.builtin.import_playbook: deploy_devbox.yml

--- a/devbox/ansible/requirements.yml
+++ b/devbox/ansible/requirements.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 collections:
   - name: community.crypto

--- a/devbox/ansible/roles/kubevirt/defaults/main.yml
+++ b/devbox/ansible/roles/kubevirt/defaults/main.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 kubevirt_version: "v1.6.2"
 kubevirt_cdi_version: "v1.63.1"

--- a/devbox/ansible/roles/kubevirt/handlers/main.yml
+++ b/devbox/ansible/roles/kubevirt/handlers/main.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 - name: Restart AppArmor
   become: true

--- a/devbox/ansible/roles/kubevirt/tasks/main.yml
+++ b/devbox/ansible/roles/kubevirt/tasks/main.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 - name: Install needed dependencies
   ansible.builtin.pip:

--- a/devbox/ansible/roles/kubevirt_vm/defaults/main.yml
+++ b/devbox/ansible/roles/kubevirt_vm/defaults/main.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 kubevirt_vm_name: devbox
 kubevirt_vm_namespace: default

--- a/devbox/ansible/roles/kubevirt_vm/tasks/main.yml
+++ b/devbox/ansible/roles/kubevirt_vm/tasks/main.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 - name: Generate SSH Key for devbox
   community.crypto.openssh_keypair:

--- a/devbox/ansible/roles/kubevirt_vm/templates/cloudconfig.yml.j2
+++ b/devbox/ansible/roles/kubevirt_vm/templates/cloudconfig.yml.j2
@@ -1,3 +1,7 @@
+{#
+SPDX-FileCopyrightText: SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+#}
 #cloud-config
 password: {{ kubevirt_vm_sles_password }}
 chpasswd:

--- a/devbox/vagrant/Vagrantfile
+++ b/devbox/vagrant/Vagrantfile
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 Vagrant.require_version ">= 1.8.0"
 
 BASE_BOX = ENV["TRENTO_VAGRANT_BASE_BOX"] || "SLES15-SP6"

--- a/devbox/vagrant/combustion.tpl.sh
+++ b/devbox/vagrant/combustion.tpl.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 # combustion: network
 
 # --- Vagrant base-box setup

--- a/devbox/vagrant/make_combustion_script.sh
+++ b/devbox/vagrant/make_combustion_script.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env sh
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 
 # Prints an error and immediately terminates the script with error
 # code `1`:

--- a/devbox/vagrant/make_sles_box.sh
+++ b/devbox/vagrant/make_sles_box.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env sh
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 
 usage() {
     echo "Usage:"

--- a/devbox/vagrant/secrets.tpl
+++ b/devbox/vagrant/secrets.tpl
@@ -1,1 +1,6 @@
+{*
+ SPDX-FileCopyrightText: SUSE LLC
+ SPDX-License-Identifier: Apache-2.0
+*}
+
 TRENTO_VAGRANT_REGCODE=""

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 FROM opensuse/leap:15
 LABEL org.opencontainers.image.source="https://github.com/trento-project/ansible"
 LABEL org.opencontainers.image.authors="Carmine Di Monaco <carmine.dimonaco@suse.com>"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 set -e
 
 usage() {

--- a/examples/dedicated-nodes/inventory.yml
+++ b/examples/dedicated-nodes/inventory.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 all:
   children:

--- a/examples/external-services/inventory.yml
+++ b/examples/external-services/inventory.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 all:
   children:

--- a/examples/single-node/inventory.yml
+++ b/examples/single-node/inventory.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 all:
   children:

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 provision_postgres: true
 provision_prometheus: true

--- a/packaging/suse/rpm/ansible-trento.spec
+++ b/packaging/suse/rpm/ansible-trento.spec
@@ -1,7 +1,8 @@
 #
 # spec file for package ansible-trento
 #
-# Copyright (c) 2025 SUSE LLC
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/packaging/suse/rpm/galaxy.yml
+++ b/packaging/suse/rpm/galaxy.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 namespace: "suse"
 name: "trento"

--- a/packaging/suse/rpm/meta/runtime.yml
+++ b/packaging/suse/rpm/meta/runtime.yml
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 requires_ansible: ">=2.16.0"

--- a/playbook.cleanup.yml
+++ b/playbook.cleanup.yml
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: SUSE LLC
 # SPDX-License-Identifier: Apache-2.0
 
-cleanup.yml
+- ansible.builtin.import_playbook: cleanup.yml

--- a/playbook.cleanup.yml
+++ b/playbook.cleanup.yml
@@ -1,4 +1,1 @@
-# SPDX-FileCopyrightText: SUSE LLC
-# SPDX-License-Identifier: Apache-2.0
-
-- ansible.builtin.import_playbook: cleanup.yml
+cleanup.yml

--- a/playbook.cleanup.yml
+++ b/playbook.cleanup.yml
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 cleanup.yml

--- a/playbook.yml
+++ b/playbook.yml
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: SUSE LLC
 # SPDX-License-Identifier: Apache-2.0
 
-site.yml
+- ansible.builtin.import_playbook: site.yml

--- a/playbook.yml
+++ b/playbook.yml
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 site.yml

--- a/playbook.yml
+++ b/playbook.yml
@@ -1,4 +1,1 @@
-# SPDX-FileCopyrightText: SUSE LLC
-# SPDX-License-Identifier: Apache-2.0
-
-- ansible.builtin.import_playbook: site.yml
+site.yml

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 collections:
   - name: community.docker

--- a/roles/agent/defaults/main.yml
+++ b/roles/agent/defaults/main.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 agent_web_api_key: "{{ undef(hint='API key for Trento Web is mandatory') }}"
 agent_trento_server_url: "{{ trento_server_url | default('http://{}'.format(trento_server_name)) }}"

--- a/roles/agent/handlers/main.yml
+++ b/roles/agent/handlers/main.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 # code: language=ansible
 ---
 - name: Restart Trento agent

--- a/roles/agent/meta/main.yml
+++ b/roles/agent/meta/main.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 galaxy_info:
   author: "trento-developers@suse.com"
   description: Install and configure Agent for Trento

--- a/roles/agent/tasks/cleanup.yml
+++ b/roles/agent/tasks/cleanup.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 # code: language=ansible
 ---
 - name: Stop and disable trento-agent service

--- a/roles/agent/tasks/main.yml
+++ b/roles/agent/tasks/main.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 # code: language=ansible
 ---
 - name: Install Trento agent

--- a/roles/agent/templates/agent.conf.j2
+++ b/roles/agent/templates/agent.conf.j2
@@ -1,3 +1,7 @@
+{#
+SPDX-FileCopyrightText: SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+#}
 {{ ansible_managed | comment }}
 
 server-url: {{ agent_trento_server_url }}

--- a/roles/agent/vars/main.yml
+++ b/roles/agent/vars/main.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 agent_host_pre_16: "{{ ansible_distribution_version is version('15.7', '<=') | bool }}"
 agent_host_post_16: "{{ ansible_distribution_version is version('16.0', '>=') | bool }}"

--- a/roles/firewall/defaults/main.yml
+++ b/roles/firewall/defaults/main.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 firewall_ports: "{{ undef() }}"
 firewall_state: "enabled"

--- a/roles/firewall/handlers/main.yml
+++ b/roles/firewall/handlers/main.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 - name: Restart FirewallD if previously running
   ansible.builtin.service:

--- a/roles/firewall/meta/main.yml
+++ b/roles/firewall/meta/main.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 galaxy_info:
   author: "trento-developers@suse.com"
   description: Install and configure Trento

--- a/roles/firewall/tasks/main.yml
+++ b/roles/firewall/tasks/main.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 - name: Identify Python package manger prefix
   block:

--- a/roles/firewall/tests/test.yml
+++ b/roles/firewall/tests/test.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 - name: Dummy test
   hosts: localhost

--- a/roles/firewall/vars/main.yml
+++ b/roles/firewall/vars/main.yml
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 ---

--- a/roles/postgres/defaults/main.yml
+++ b/roles/postgres/defaults/main.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 postgres_install: "{{ install_postgres | default(true) }}" # `install_postgres` is for backwards-compatibility
 postgres_web_username: "{{ trento_web_postgres_username }}"

--- a/roles/postgres/handlers/main.yml
+++ b/roles/postgres/handlers/main.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 # code: language=ansible
 ---
 - name: Restart postgres

--- a/roles/postgres/meta/main.yml
+++ b/roles/postgres/meta/main.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 galaxy_info:
   author: "trento-developers@suse.com"
   description: Configure Postgres for the purposes of Trento Project

--- a/roles/postgres/tasks/cleanup.yml
+++ b/roles/postgres/tasks/cleanup.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 # code: language=ansible
 ---
 - name: Cleanup Postgres installation

--- a/roles/postgres/tasks/main.yml
+++ b/roles/postgres/tasks/main.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 # code: language=ansible
 ---
 - name: Install postgresql

--- a/roles/prometheus/defaults/main.yml
+++ b/roles/prometheus/defaults/main.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 prometheus_port: "{{ trento_prometheus_port }}"
 prometheus_web_url: "{{ web_host | default('http://{}'.format(trento_server_name)) }}" # `web_host` is for backwards-compatibility

--- a/roles/prometheus/handlers/main.yml
+++ b/roles/prometheus/handlers/main.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 # code: language=ansible
 ---
 - name: Restart Prometheus

--- a/roles/prometheus/meta/main.yml
+++ b/roles/prometheus/meta/main.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 galaxy_info:
   author: "trento-developers@suse.com"
   description: Configure Prometheus for the purposes of Trento Project

--- a/roles/prometheus/tasks/cleanup.yml
+++ b/roles/prometheus/tasks/cleanup.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 # code: language=ansible
 ---
 # It's intentionally empty. Used in cleanup to load the variables for

--- a/roles/prometheus/tasks/main.yml
+++ b/roles/prometheus/tasks/main.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 # code: language=ansible
 ---
 - name: Ensure prometheus group is present

--- a/roles/prometheus/templates/prometheus-sysconfig.j2
+++ b/roles/prometheus/templates/prometheus-sysconfig.j2
@@ -1,3 +1,7 @@
+{#
+SPDX-FileCopyrightText: SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+#}
 ## Path:
 ## Description: Prometheus monitoring server settings
 ## Type:        string

--- a/roles/prometheus/templates/prometheus.yml.j2
+++ b/roles/prometheus/templates/prometheus.yml.j2
@@ -1,3 +1,7 @@
+{#
+SPDX-FileCopyrightText: SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+#}
 global:
   scrape_interval: 30s
   evaluation_interval: 10s

--- a/roles/rabbitmq/defaults/main.yml
+++ b/roles/rabbitmq/defaults/main.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 rabbitmq_username: "{{ trento_rabbitmq_username }}"
 rabbitmq_password: "{{ trento_rabbitmq_password }}"

--- a/roles/rabbitmq/meta/main.yml
+++ b/roles/rabbitmq/meta/main.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 galaxy_info:
   author: "trento-developers@suse.com"
   description: Configure RabbitMQ for the purposes of Trento Project

--- a/roles/rabbitmq/tasks/cleanup.yml
+++ b/roles/rabbitmq/tasks/cleanup.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 # code: language=ansible
 ---
 - name: Remove rabbitmq trento user

--- a/roles/rabbitmq/tasks/main.yml
+++ b/roles/rabbitmq/tasks/main.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 # code: language=ansible
 ---
 - name: Install RabbitMQ

--- a/roles/rproxy/defaults/main/deprecated.yml
+++ b/roles/rproxy/defaults/main/deprecated.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 install_nginx: true
 override_nginx_default_conf: true

--- a/roles/rproxy/defaults/main/main.yml
+++ b/roles/rproxy/defaults/main/main.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 rproxy_install: "{{ install_nginx }}"
 rproxy_server_name: "{{ trento_server_name }}"

--- a/roles/rproxy/handlers/main.yml
+++ b/roles/rproxy/handlers/main.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 # code: language=ansible
 ---
 - name: Restart nginx

--- a/roles/rproxy/tasks/cleanup.yml
+++ b/roles/rproxy/tasks/cleanup.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 # code: language=ansible
 ---
 - name: Remove nginx vhost file

--- a/roles/rproxy/tasks/main.yml
+++ b/roles/rproxy/tasks/main.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 # code: language=ansible
 ---
 - name: Install nginx

--- a/roles/rproxy/templates/nginx-default.conf.j2
+++ b/roles/rproxy/templates/nginx-default.conf.j2
@@ -1,3 +1,7 @@
+{#
+SPDX-FileCopyrightText: SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+#}
 worker_processes  1;
 
 events {

--- a/roles/rproxy/templates/trento.conf.j2
+++ b/roles/rproxy/templates/trento.conf.j2
@@ -1,3 +1,7 @@
+{#
+SPDX-FileCopyrightText: SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+#}
 map $http_upgrade $connection_upgrade {
   default upgrade;
   '' close;

--- a/roles/rproxy/vars/main.yml
+++ b/roles/rproxy/vars/main.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 rproxy_conf_base_dir: "/etc/nginx"
 rproxy_vhost_dir: "vhosts.d"

--- a/roles/supportutils/defaults/main.yml
+++ b/roles/supportutils/defaults/main.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 supportutils_enabled: true
 supportutils_package_name: supportutils

--- a/roles/supportutils/meta/main.yml
+++ b/roles/supportutils/meta/main.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 galaxy_info:
   author: "trento-developers@suse.com"
   description: Install Trento support tooling on server and agent hosts

--- a/roles/supportutils/tasks/cleanup.yml
+++ b/roles/supportutils/tasks/cleanup.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 # code: language=ansible
 ---
 - name: Remove Trento support plugin

--- a/roles/supportutils/tasks/main.yml
+++ b/roles/supportutils/tasks/main.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 # code: language=ansible
 ---
 - name: Install Trento support tooling

--- a/roles/trento/defaults/main.yml
+++ b/roles/trento/defaults/main.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 # WARNING! Please, put variables here only after careful
 # consideration. Put variables only if they are really common among

--- a/roles/trento/meta/main.yml
+++ b/roles/trento/meta/main.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 galaxy_info:
   author: "trento-developers@suse.com"
   description: Meta-role for common trento-related variables

--- a/roles/trento/tasks/main.yml
+++ b/roles/trento/tasks/main.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 - name: Show host discovery results for Postgres
   ansible.builtin.debug:

--- a/roles/trento/vars/main.yml
+++ b/roles/trento/vars/main.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 #
 # Protected values -- The following values are not intended to be

--- a/roles/wanda/defaults/main.yml
+++ b/roles/wanda/defaults/main.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 wanda_listen_port: "{{ trento_wanda_listen_port }}"
 wanda_proxy_location: "{{ trento_wanda_proxy_location }}"

--- a/roles/wanda/handlers/main.yml
+++ b/roles/wanda/handlers/main.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 - name: Restart trento-wanda
   ansible.builtin.service:

--- a/roles/wanda/meta/main.yml
+++ b/roles/wanda/meta/main.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 galaxy_info:
   author: "trento-developers@suse.com"
   description: Install and configure Trento Wanda

--- a/roles/wanda/tasks/cleanup.yml
+++ b/roles/wanda/tasks/cleanup.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 - name: Check installation method
   ansible.builtin.assert:

--- a/roles/wanda/tasks/docker.yml
+++ b/roles/wanda/tasks/docker.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 - name: Include Docker installation variables
   ansible.builtin.include_vars: "../vars/docker.yml"

--- a/roles/wanda/tasks/docker_cleanup.yml
+++ b/roles/wanda/tasks/docker_cleanup.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 - name: Include Docker installation variables
   ansible.builtin.include_vars: "../vars/docker.yml"

--- a/roles/wanda/tasks/main.yml
+++ b/roles/wanda/tasks/main.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 - name: Check installation method
   ansible.builtin.assert:

--- a/roles/wanda/tasks/rpm.yml
+++ b/roles/wanda/tasks/rpm.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 - name: Install Trento Wanda RPM packages
   community.general.zypper:

--- a/roles/wanda/tasks/rpm_cleanup.yml
+++ b/roles/wanda/tasks/rpm_cleanup.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 - name: Disable and stop trento-wanda service
   ansible.builtin.service:

--- a/roles/wanda/templates/trento-wanda.j2
+++ b/roles/wanda/templates/trento-wanda.j2
@@ -1,3 +1,7 @@
+{#
+SPDX-FileCopyrightText: SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+#}
 CORS_ORIGIN=http://localhost
 SECRET_KEY_BASE={{ wanda_secret_key_base }}
 AMQP_URL={{ wanda_amqp_protocol }}://{{ wanda_rabbitmq_username }}:{{ wanda_rabbitmq_password }}@{{ wanda_rabbitmq_host }}/{{ wanda_rabbitmq_vhost | urlencode | replace('/', '%2F') }}

--- a/roles/wanda/vars/docker.yml
+++ b/roles/wanda/vars/docker.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 wanda_docker_network_name: "{{ trento_docker_network_name }}"
 wanda_force_pull_images: "{{ trento_force_pull_images }}"

--- a/roles/wanda/vars/main.yml
+++ b/roles/wanda/vars/main.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 # Protected values -- The following values are not intended to be
 # specified by end-users:

--- a/roles/web/defaults/main/deprecated.yml
+++ b/roles/web/defaults/main/deprecated.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 # DON'T ADD NEW VALUES TO THIS FILE!
 # It's only available for backwards-compatibility and smooth

--- a/roles/web/defaults/main/main.yml
+++ b/roles/web/defaults/main/main.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 web_server_name: "{{ trento_server_name }}"
 web_listen_port: "{{ trento_web_listen_port }}"

--- a/roles/web/handlers/main.yml
+++ b/roles/web/handlers/main.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 # code: language=ansible
 ---
 - name: Restart trento-web

--- a/roles/web/meta/main.yml
+++ b/roles/web/meta/main.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 galaxy_info:
   author: "trento-developers@suse.com"
   description: Install and configure Trento Web

--- a/roles/web/tasks/cleanup.yml
+++ b/roles/web/tasks/cleanup.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 - name: Check installation method
   ansible.builtin.assert:

--- a/roles/web/tasks/docker.yml
+++ b/roles/web/tasks/docker.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 # code: language=ansible
 ---
 - name: Include Docker installation variables

--- a/roles/web/tasks/docker_cleanup.yml
+++ b/roles/web/tasks/docker_cleanup.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 # code: language=ansible
 ---
 - name: Include Docker installation variables

--- a/roles/web/tasks/main.yml
+++ b/roles/web/tasks/main.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 - name: Check installation method
   ansible.builtin.assert:

--- a/roles/web/tasks/rpm.yml
+++ b/roles/web/tasks/rpm.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 # code: language=ansible
 ---
 - name: Install Trento Web RPM packages

--- a/roles/web/tasks/rpm_cleanup.yml
+++ b/roles/web/tasks/rpm_cleanup.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 # code: language=ansible
 ---
 - name: Disable and stop trento-web service

--- a/roles/web/templates/trento-web.j2
+++ b/roles/web/templates/trento-web.j2
@@ -1,3 +1,7 @@
+{#
+SPDX-FileCopyrightText: SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+#}
 AMQP_URL={{ web_amqp_protocol }}://{{ web_rabbitmq_username }}:{{ web_rabbitmq_password }}@{{ web_rabbitmq_host }}/{{ web_rabbitmq_vhost | urlencode | replace('/', '%2F') }}
 DATABASE_URL=ecto://{{ web_postgres_username }}:{{ web_postgres_password }}@{{ web_postgres_host }}/{{ web_postgres_db }}
 EVENTSTORE_URL=ecto://{{ web_postgres_username }}:{{ web_postgres_password }}@{{ web_postgres_host }}/{{ web_postgres_event_store }}

--- a/roles/web/vars/docker.yml
+++ b/roles/web/vars/docker.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 web_docker_network_name: "{{ trento_docker_network_name }}"
 web_force_pull_images: "{{ trento_force_pull_images }}"

--- a/roles/web/vars/main.yml
+++ b/roles/web/vars/main.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 #
 # Protected values -- The following values are not intended to be

--- a/scripts/make_single_node.sh
+++ b/scripts/make_single_node.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
+
 # This script creates the necessary files to run the Ansible playbook
 # for a single node installation of Trento.
 # It generates a self-signed certificate and creates the inventory and

--- a/server.yml
+++ b/server.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 - name: Check if Trento would be installed on SLES
   hosts: trento_server

--- a/site.yml
+++ b/site.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 - name: Provision Trento server components
   ansible.builtin.import_playbook: server.yml


### PR DESCRIPTION
# Description

In an attempt to follow the REUSE Specification (supported by the Linux Foundation) for managing licence information, this PR adds the recommended `SPDX-FileCopyrightText` and `SPDX-License-Identifier` headers.

Besides, a new linter is added for the CI to check the license headers. 

Related # TRNT-4358

## How was this tested?

License linter.