### PR TITLE
Cancel stale CI runs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,9 @@ on:
     paths-ignore:
       - "VERSION"
 
-concurrency: ${{ github.workflow }}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   ansible-lint:


### PR DESCRIPTION
## Summary

Update the CI workflow concurrency configuration so that stale runs are cancelled when newer commits are pushed to the same branch or pull request.

This changes the concurrency group from a workflow-wide group to a workflow/ref group and enables `cancel-in-progress`, matching the pattern used in other repositories.
