### PR TITLE
Add SLES16 CI target

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,7 +49,7 @@ jobs:
           ansible-galaxy collection list
 
   test-deploy:
-    name: Run ansible${{ matrix.control_node.ansible_version }} on ${{ matrix.install_method }}/SLES15-${{ matrix.sp_version }}
+    name: Run ansible${{ matrix.control_node.ansible_version }} on ${{ matrix.install_method }}/${{ matrix.target.label }}
     needs: [ansible-lint]
     runs-on: ubuntu-24.04
     strategy:
@@ -62,21 +62,36 @@ jobs:
           - ansible_version: "9"
             target_python: python3
         install_method: ["rpm", "docker"]
-        sp_version: ['SP7', 'SP6', 'SP5', 'SP4']
+        target:
+          - label: SLES15-SP7
+            host_var: TEST_SP7_HOST_IP
+          - label: SLES15-SP6
+            host_var: TEST_SP6_HOST_IP
+          - label: SLES15-SP5
+            host_var: TEST_SP5_HOST_IP
+          - label: SLES15-SP4
+            host_var: TEST_SP4_HOST_IP
+          - label: SLES16.0
+            host_var: TEST_SLES16_HOST_IP
+            target_python: python3
 
         exclude:
-          - sp_version: "SP4"
+          - target:
+              label: SLES15-SP4
+              host_var: TEST_SP4_HOST_IP
             control_node:
               ansible_version: "11"
               target_python: python3.11
 
-          - sp_version: "SP5"
+          - target:
+              label: SLES15-SP5
+              host_var: TEST_SP5_HOST_IP
             control_node:
               ansible_version: "11"
               target_python: python3.11
 
     env:
-      TEST_HOST_IP: ${{ vars[format('TEST_{0}_HOST_IP', matrix.sp_version)] }}
+      TEST_HOST_IP: ${{ vars[matrix.target.host_var] }}
 
     steps:
       - name: Checkout repo
@@ -101,7 +116,7 @@ jobs:
             all:
               vars:
                 ansible_user: ${{ secrets.TEST_HOST_USER }}
-                ansible_python_interpreter: /usr/bin/${{ matrix.control_node.target_python }}
+                ansible_python_interpreter: /usr/bin/${{ matrix.target.target_python || matrix.control_node.target_python }}
               children:
                 trento_server:
                   hosts:
@@ -157,7 +172,7 @@ jobs:
             all:
               vars:
                 ansible_user: ${{ secrets.TEST_HOST_USER }}
-                ansible_python_interpreter: /usr/bin/${{ matrix.control_node.target_python }}
+                ansible_python_interpreter: /usr/bin/${{ matrix.target.target_python || matrix.control_node.target_python }}
               children:
                 trento_server:
                   hosts:


### PR DESCRIPTION
## Summary
- add SLES16.0 to the CI deployment matrix
- route SLES16 to the new TEST_SLES16_HOST_IP repository variable
- keep SLES16 on /usr/bin/python3 because the VM does not provide python3.11