### PR TITLE
Create Prometheus tmpfiles before service startup

### DIFF
--- a/roles/prometheus/tasks/main.yml
+++ b/roles/prometheus/tasks/main.yml
@@ -23,9 +23,16 @@
     name: golang-github-prometheus-prometheus
     state: present
 
+- name: Check Prometheus tmpfiles config
+  ansible.builtin.stat:
+    path: /usr/lib/tmpfiles.d/prometheus.conf
+  register: prometheus_tmpfiles_config
+
 - name: Create Prometheus directories from tmpfiles
-  ansible.builtin.command: systemd-tmpfiles --create /usr/lib/tmpfiles.d/prometheus.conf
+  ansible.builtin.command:
+    cmd: systemd-tmpfiles --create /usr/lib/tmpfiles.d/prometheus.conf
   changed_when: false
+  when: prometheus_tmpfiles_config.stat.exists
 
 - name: Create Prometheus config
   ansible.builtin.template:

--- a/roles/prometheus/tasks/main.yml
+++ b/roles/prometheus/tasks/main.yml
@@ -23,6 +23,10 @@
     name: golang-github-prometheus-prometheus
     state: present
 
+- name: Create Prometheus directories from tmpfiles
+  ansible.builtin.command: systemd-tmpfiles --create /usr/lib/tmpfiles.d/prometheus.conf
+  changed_when: false
+
 - name: Create Prometheus config
   ansible.builtin.template:
     src: prometheus.yml.j2


### PR DESCRIPTION
### Description

Create the Prometheus package-managed runtime directories before starting the service.

On SLES 15 SP7, `golang-github-prometheus-prometheus` 3.5.3 uses `/var/lib/prometheus/metrics` as its default TSDB path. When that directory has not been created yet, Prometheus exits during startup with:

```text
open /var/lib/prometheus/metrics/queries.active: no such file or directory
panic: Unable to create mmap-ed active query log
```

The role now checks whether the package-provided tmpfiles configuration exists and runs `systemd-tmpfiles --create /usr/lib/tmpfiles.d/prometheus.conf` before rendering the configuration and starting Prometheus. This keeps the fix distribution-driven and avoids hardcoding SLES-version-specific paths.

### How was this tested?

Validated with a local inventory matching the installation automation workflow across:

- SLES 15 SP4
- SLES 15 SP5
- SLES 15 SP6
- SLES 15 SP7
- SLES 16.0

The playbook completed successfully and Prometheus was confirmed running on the configured port.

### Documentation changes

No. This is an internal provisioning fix for package-managed runtime directories and does not change user-facing configuration or behavior.

### Additional information

The `stat` guard keeps the task safe for distributions or package versions that do not ship `/usr/lib/tmpfiles.d/prometheus.conf`.
