### PR TITLE
Fix typos

### DIFF
--- a/devbox/ansible/roles/kubevirt_vm/templates/cloudconfig.yml.j2
+++ b/devbox/ansible/roles/kubevirt_vm/templates/cloudconfig.yml.j2
@@ -43,7 +43,7 @@ write_files:
     # Install SLES_SAP default packages
     zypper -n install --auto-agree-with-licenses -f patterns-server-enterprise-sap_server
 
-    # --- Enable optinal SUSE modules
+    # --- Enable optional SUSE modules
     # Note: This section should ideally be handled in our ansible
     # playbook. However, for now, we'll configure it here.
     SLES_OPTIONAL_MODULES="PackageHub sle-module-containers"

--- a/devbox/vagrant/combustion.tpl.sh
+++ b/devbox/vagrant/combustion.tpl.sh
@@ -75,7 +75,7 @@ done
 # Install SLES_SAP default packages
 zypper -n install --auto-agree-with-licenses -f patterns-server-enterprise-sap_server
 
-# --- Enable optinal SUSE modules
+# --- Enable optional SUSE modules
 # Note: This section should ideally be handled in our ansible
 # playbook. However, for now, we'll configure it here.
 SLES_OPTIONAL_MODULES="PackageHub sle-module-containers"

--- a/docs/local-development-kubevirt.adoc
+++ b/docs/local-development-kubevirt.adoc
@@ -22,12 +22,12 @@ based on https://k3s.io/[K3s]. Or you can use a cluster of you own or
 a cluster you have admin access to.
 
 In that Kubernetes cluster, KubeVirt and its sibling project CDI
-(Containerezed Data Importer) are deployed as Operators. KubeVirt
+(Containerized Data Importer) are deployed as Operators. KubeVirt
 allows management of virtual machines in Kubernetes by extending its
 API with custom resource definitions (CRDs) -- VirtualMachine (VM) and
 VirtualMachineInstance (VMI). VMI represent a _running_ virtual
 machine, while VM resource tracks the state of VMI (similar to
-Deployment and Pod resources in Kuberentes itself).
+Deployment and Pod resources in Kubernetes itself).
 
 For every VMI there is a backing pod running QEMU. The name of the pod
 is prefixed as `virt-launcher-`. These pods could be thought of as
@@ -55,7 +55,7 @@ although with the corresponding performance hit.
 
 CDI is a project that simplifies the workings with VM images. It can
 import VM images from various sources (eg. HTTP/S, container
-repositories, cloning) and seamlessly represent them as Kuberentes
+repositories, cloning) and seamlessly represent them as Kubernetes
 PVCs. This project is used to download the prepared images for use in
 this workflow in a declarative fashion.
 
@@ -422,7 +422,7 @@ $ kubectl delete vm <name-of-devbox>
 ----
 
 If you you have installed k3s cluster manually on you developer
-machine, you can uninstall it by executing the follwoing:
+machine, you can uninstall it by executing the following:
 
 [source, bash]
 ----

--- a/examples/single-node/inventory.yml
+++ b/examples/single-node/inventory.yml
@@ -48,6 +48,6 @@ all:
     web_alert_sender: "alert-sender-mail"
     web_alert_recipient: "alert-receiver-mail"
     web_smtp_server: "smtp-server-address"
-    web_smtp_port: "smpt-port"
+    web_smtp_port: "smtp-port"
     web_smtp_user: "smtp-user"
     web_smtp_password: "smtp-password"

--- a/roles/postgres/tasks/main.yml
+++ b/roles/postgres/tasks/main.yml
@@ -96,7 +96,7 @@
         comment: "Wanda user provisioned by playbook"
         state: present
 
-    - name: Grant privilegies to the web user for the web database
+    - name: Grant privileges to the web user for the web database
       community.postgresql.postgresql_privs:
         login_db: "{{ postgres_web_db }}"
         objs: public
@@ -105,7 +105,7 @@
         type: schema
         state: present
 
-    - name: Grant privilegies to the web user for the web event store
+    - name: Grant privileges to the web user for the web event store
       community.postgresql.postgresql_privs:
         login_db: "{{ postgres_web_event_store }}"
         objs: public
@@ -114,7 +114,7 @@
         type: schema
         state: present
 
-    - name: Grant privilegies to the wanda user for the wanda database
+    - name: Grant privileges to the wanda user for the wanda database
       community.postgresql.postgresql_privs:
         login_db: "{{ postgres_wanda_db }}"
         objs: public


### PR DESCRIPTION
### Description

This pull request addresses several minor spelling and typographical errors across documentation, configuration, and Ansible playbook files. The changes improve clarity and professionalism by correcting misspelled words and ensuring consistency in terminology.

* Fixed multiple typos in `docs/local-development-kubevirt.adoc`, correcting words like "Containerezed" to "Containerized", "Kuberentes" to "Kubernetes", and "follwoing" to "following" for better readability. 
* Corrected "optinal" to "optional" in comments within `devbox/vagrant/combustion.tpl.sh` and `devbox/ansible/roles/kubevirt_vm/templates/cloudconfig.yml.j2`. 
* Fixed a typo in the `examples/single-node/inventory.yml` file, changing "smpt-port" to "smtp-port" for the `web_smtp_port`
* Corrected the spelling of "privilegies" to "privileges" 

Related #TRNT-4463

### How was this tested?

CI

### Documentation changes

No

### Additional information

N/A