### PR TITLE
Autoregister modules with SUSEConnect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -193,6 +193,9 @@ extra-vars.json
 
 data/
 
+# Roles fetched via `ansible-galaxy install -r requirements.yml`
+/roles/suseconnect/
+
 # Devbox files containing secrets
 devbox/combustion.sh
 devbox/secrets

--- a/README.adoc
+++ b/README.adoc
@@ -74,8 +74,12 @@ inventory.
 *This playbook requires that the host where you are going to install
 Trento server components has an activated license* for one of the
 supported OSs, with the following modules (Change `x` to match your
-current version):
-On SLES15:
+current version).
+
+Instead of registering by hand, set `enable_autoregister` to `true` to
+have every host in the play register the modules above itself (via the
+https://github.com/SUSE/ansible-suseconnect[suseconnect] role).
+
 On SLES 15:
 
 * Basesystem Module 15 x86_64 - `SUSEConnect -p sle-module-basesystem/15.x/x86_64`
@@ -340,6 +344,11 @@ population of some variables.
 
 | provision_prometheus | Whether to provision Prometheus used by Trento to store
   metrics send by agents | true
+
+| enable_autoregister | Whether to automatically register the SCC
+  modules required for the host's SLES version via `SUSEConnect`,
+  instead of registering them by hand (see the SUSE Linux Enterprise Users section above).
+  | false
 
 |===
 

--- a/README.adoc
+++ b/README.adoc
@@ -216,7 +216,7 @@ modules:
 
 [source, console]
 ----
-$ ansible-galaxy collection install -r requirements.yml
+$ ansible-galaxy install -r requirements.yml
 ----
 
 Run a playbook:

--- a/README.adoc
+++ b/README.adoc
@@ -75,13 +75,17 @@ inventory.
 Trento server components has an activated license* for one of the
 supported OSs, with the following modules (Change `x` to match your
 current version):
+On SLES15:
+On SLES 15:
 
-* Basesystem Module 15 x86_64 -
-`SUSEConnect -p sle-module-basesystem/15.x/x86_64`
+* Basesystem Module 15 x86_64 - `SUSEConnect -p sle-module-basesystem/15.x/x86_64`
 * SUSE Package Hub 15 x86_64 - `SUSEConnect -p PackageHub/15.x/x86_64`
 * Python 3 module - `SUSEConnect -p sle-module-python3/15.x/x86_64`
-* (15.6 only) Legacy Module 15 x86_64 -
-`SUSEConnect -p sle-module-legacy/15.6/x86_64`
+* (15.6 only) Legacy Module 15 x86_64 - `SUSEConnect -p sle-module-legacy/15.6/x86_64`
+
+On SLES 16:
+
+* SUSE Package Hub 16 x86_64 - `SUSEConnect -p PackageHub/16.x/x86_64`
 
 === Agent
 
@@ -751,16 +755,16 @@ More detailed info about usage and defaults available link:https://github.com/tr
 |===
 |Name | Description | Default
 
-| agent_prometheus_mode | 
-  Whether to use Prometheus in "pull" mode with prometheus node exporters or in "push" mode with grafana alloy. | 
+| agent_prometheus_mode |
+  Whether to use Prometheus in "pull" mode with prometheus node exporters or in "push" mode with grafana alloy. |
   If unspecified it resolves to "pull" for SLES \<= 15.7 and "pull" for SLES 16 and above.
 
-| agent_prometheus_exporter_name | 
-  Exporter name used in host discovery. | 
+| agent_prometheus_exporter_name |
+  Exporter name used in host discovery. |
   "node_exporter" in case of prometheus "pull" mode, "grafana_alloy" in case of "push" mode.
 
-| agent_prometheus_node_exporter_target | 
-  The target address of the node exporter to scrape metrics from, in case `agent_prometheus_mode` is set to "pull". | 
+| agent_prometheus_node_exporter_target |
+  The target address of the node exporter to scrape metrics from, in case `agent_prometheus_mode` is set to "pull". |
   Defaults to the lowest discovered IP address with a default port number (9100).
 
 | agent_prometheus_remote_write_url | The remote write URL of the Prometheus server, in case `agent_prometheus_mode` is set to "push". | "https://<value of `trento_server_name`>/prometheus/api/v1/write"

--- a/devbox/ansible/requirements.yml
+++ b/devbox/ansible/requirements.yml
@@ -14,4 +14,4 @@ collections:
 
   - name: https://github.com/k3s-io/k3s-ansible.git
     type: git
-    version: 1.0.1
+    version: 1.2.1

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -6,3 +6,4 @@ provision_postgres: true
 provision_prometheus: true
 provision_rabbitmq: true
 provision_proxy: true
+enable_autoregister: false

--- a/requirements.yml
+++ b/requirements.yml
@@ -13,3 +13,8 @@ collections:
     version: 3.14.2
   - name: ansible.posix
     version: 1.6.2
+
+roles:
+  - name: suseconnect
+    src: https://github.com/SUSE/ansible-suseconnect.git
+    version: 1.0.2-suse

--- a/roles/agent/tasks/main.yml
+++ b/roles/agent/tasks/main.yml
@@ -43,12 +43,21 @@
     enabled: true
 
 - name: Install 'node_exporter' on SLES 15.7 and earlier
-  community.general.zypper:
-    name: golang-github-prometheus-node_exporter
-    state: latest
   when: agent_install_monitoring_dep and agent_prometheus_mode_pull
   notify:
     - Restart Prometheus node_exporter service
+  block:
+    - name: Install node_exporter package
+      community.general.zypper:
+        name: golang-github-prometheus-node_exporter
+        state: latest
+  rescue:
+    - name: Fail with Package Hub guidance
+      ansible.builtin.fail:
+        msg: >-
+          Failed to install golang-github-prometheus-node_exporter.
+          Register SUSE Package Hub first: SUSEConnect -p
+          PackageHub/{{ ansible_facts['distribution_version'] }}/{{ ansible_facts['architecture'] }}
 
 - name: Install and configure alloy on SLES 16 and later
   when: agent_install_monitoring_dep and agent_prometheus_mode_push

--- a/roles/agent/tasks/main.yml
+++ b/roles/agent/tasks/main.yml
@@ -5,7 +5,7 @@
 ---
 - name: Determine SUSE modules to register
   ansible.builtin.set_fact:
-    suseconnect_subscriptions: >-
+    agent_suseconnect_subscriptions: >-
       {{
         [{'name': 'PackageHub', 'state': 'enabled'}]
         if (ansible_facts['distribution_major_version'] | int >= 16)
@@ -24,6 +24,8 @@
 - name: Register with SCC and activate modules
   ansible.builtin.include_role:
     name: suseconnect
+  vars:
+    suseconnect_subscriptions: "{{ agent_suseconnect_subscriptions }}"
   when: enable_autoregister | bool
 
 - name: Install Trento agent

--- a/roles/agent/tasks/main.yml
+++ b/roles/agent/tasks/main.yml
@@ -3,6 +3,29 @@
 
 # code: language=ansible
 ---
+- name: Determine SUSE modules to register
+  ansible.builtin.set_fact:
+    suseconnect_subscriptions: >-
+      {{
+        [{'name': 'PackageHub', 'state': 'enabled'}]
+        if (ansible_facts['distribution_major_version'] | int >= 16)
+        else
+        (
+          [
+            {'name': 'sle-module-basesystem', 'state': 'enabled'},
+            {'name': 'PackageHub', 'state': 'enabled'},
+            {'name': 'sle-module-python3', 'state': 'enabled'}
+          ]
+          + ([{'name': 'sle-module-legacy', 'state': 'enabled'}] if ansible_facts['distribution_version'] == '15.6' else [])
+        )
+      }}
+  when: enable_autoregister | bool
+
+- name: Register with SCC and activate modules
+  ansible.builtin.include_role:
+    name: suseconnect
+  when: enable_autoregister | bool
+
 - name: Install Trento agent
   community.general.zypper:
     name: trento-agent

--- a/roles/firewall/tasks/main.yml
+++ b/roles/firewall/tasks/main.yml
@@ -4,7 +4,7 @@
 ---
 - name: Determine SUSE modules to register
   ansible.builtin.set_fact:
-    suseconnect_subscriptions: >-
+    firewall_suseconnect_subscriptions: >-
       {{
         []
         if (ansible_facts['distribution_major_version'] | int >= 16)
@@ -22,9 +22,11 @@
 - name: Register with SCC and activate modules
   ansible.builtin.include_role:
     name: suseconnect
+  vars:
+    suseconnect_subscriptions: "{{ firewall_suseconnect_subscriptions }}"
   when:
     - enable_autoregister | bool
-    - suseconnect_subscriptions | default([]) | length > 0
+    - firewall_suseconnect_subscriptions | default([]) | length > 0
 
 - name: Identify Python package manger prefix
   block:

--- a/roles/firewall/tasks/main.yml
+++ b/roles/firewall/tasks/main.yml
@@ -2,6 +2,30 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
+- name: Determine SUSE modules to register
+  ansible.builtin.set_fact:
+    suseconnect_subscriptions: >-
+      {{
+        []
+        if (ansible_facts['distribution_major_version'] | int >= 16)
+        else
+        (
+          [
+            {'name': 'sle-module-basesystem', 'state': 'enabled'},
+            {'name': 'sle-module-python3', 'state': 'enabled'}
+          ]
+          + ([{'name': 'sle-module-legacy', 'state': 'enabled'}] if ansible_facts['distribution_version'] == '15.6' else [])
+        )
+      }}
+  when: enable_autoregister | bool
+
+- name: Register with SCC and activate modules
+  ansible.builtin.include_role:
+    name: suseconnect
+  when:
+    - enable_autoregister | bool
+    - suseconnect_subscriptions | default([]) | length > 0
+
 - name: Identify Python package manger prefix
   block:
     - name: Get current Python's package manger prefix

--- a/roles/postgres/tasks/main.yml
+++ b/roles/postgres/tasks/main.yml
@@ -5,7 +5,7 @@
 ---
 - name: Determine SUSE modules to register
   ansible.builtin.set_fact:
-    suseconnect_subscriptions: >-
+    postgres_suseconnect_subscriptions: >-
       {{
         []
         if (ansible_facts['distribution_major_version'] | int >= 16)
@@ -23,9 +23,11 @@
 - name: Register with SCC and activate modules
   ansible.builtin.include_role:
     name: suseconnect
+  vars:
+    suseconnect_subscriptions: "{{ postgres_suseconnect_subscriptions }}"
   when:
     - enable_autoregister | bool
-    - suseconnect_subscriptions | default([]) | length > 0
+    - postgres_suseconnect_subscriptions | default([]) | length > 0
 
 - name: Install postgresql
   when: postgres_install | bool

--- a/roles/postgres/tasks/main.yml
+++ b/roles/postgres/tasks/main.yml
@@ -3,6 +3,30 @@
 
 # code: language=ansible
 ---
+- name: Determine SUSE modules to register
+  ansible.builtin.set_fact:
+    suseconnect_subscriptions: >-
+      {{
+        []
+        if (ansible_facts['distribution_major_version'] | int >= 16)
+        else
+        (
+          [
+            {'name': 'sle-module-basesystem', 'state': 'enabled'},
+            {'name': 'sle-module-python3', 'state': 'enabled'}
+          ]
+          + ([{'name': 'sle-module-legacy', 'state': 'enabled'}] if ansible_facts['distribution_version'] == '15.6' else [])
+        )
+      }}
+  when: enable_autoregister | bool
+
+- name: Register with SCC and activate modules
+  ansible.builtin.include_role:
+    name: suseconnect
+  when:
+    - enable_autoregister | bool
+    - suseconnect_subscriptions | default([]) | length > 0
+
 - name: Install postgresql
   when: postgres_install | bool
   community.general.zypper:

--- a/roles/prometheus/tasks/main.yml
+++ b/roles/prometheus/tasks/main.yml
@@ -3,6 +3,29 @@
 
 # code: language=ansible
 ---
+- name: Determine SUSE modules to register
+  ansible.builtin.set_fact:
+    suseconnect_subscriptions: >-
+      {{
+        [{'name': 'PackageHub', 'state': 'enabled'}]
+        if (ansible_facts['distribution_major_version'] | int >= 16)
+        else
+        (
+          [
+            {'name': 'sle-module-basesystem', 'state': 'enabled'},
+            {'name': 'PackageHub', 'state': 'enabled'},
+            {'name': 'sle-module-python3', 'state': 'enabled'}
+          ]
+          + ([{'name': 'sle-module-legacy', 'state': 'enabled'}] if ansible_facts['distribution_version'] == '15.6' else [])
+        )
+      }}
+  when: enable_autoregister | bool
+
+- name: Register with SCC and activate modules
+  ansible.builtin.include_role:
+    name: suseconnect
+  when: enable_autoregister | bool
+
 - name: Ensure prometheus group is present
   ansible.builtin.group:
     name: prometheus

--- a/roles/prometheus/tasks/main.yml
+++ b/roles/prometheus/tasks/main.yml
@@ -5,7 +5,7 @@
 ---
 - name: Determine SUSE modules to register
   ansible.builtin.set_fact:
-    suseconnect_subscriptions: >-
+    prometheus_suseconnect_subscriptions: >-
       {{
         [{'name': 'PackageHub', 'state': 'enabled'}]
         if (ansible_facts['distribution_major_version'] | int >= 16)
@@ -24,6 +24,8 @@
 - name: Register with SCC and activate modules
   ansible.builtin.include_role:
     name: suseconnect
+  vars:
+    suseconnect_subscriptions: "{{ prometheus_suseconnect_subscriptions }}"
   when: enable_autoregister | bool
 
 - name: Ensure prometheus group is present

--- a/roles/prometheus/tasks/main.yml
+++ b/roles/prometheus/tasks/main.yml
@@ -18,10 +18,19 @@
     comment: "User for Prometheus service"
   when: ansible_distribution_version >= "15.4"
 
-- name: Install package using zypper module
-  ansible.builtin.package:
-    name: golang-github-prometheus-prometheus
-    state: present
+- name: Install Prometheus package
+  block:
+    - name: Install package using zypper module
+      ansible.builtin.package:
+        name: golang-github-prometheus-prometheus
+        state: present
+  rescue:
+    - name: Fail with Package Hub guidance
+      ansible.builtin.fail:
+        msg: >-
+          Failed to install golang-github-prometheus-prometheus.
+          Register SUSE Package Hub first: SUSEConnect -p
+          PackageHub/{{ ansible_facts['distribution_version'] }}/{{ ansible_facts['architecture'] }}
 
 - name: Check Prometheus tmpfiles config
   ansible.builtin.stat:

--- a/roles/rabbitmq/tasks/main.yml
+++ b/roles/rabbitmq/tasks/main.yml
@@ -3,6 +3,30 @@
 
 # code: language=ansible
 ---
+- name: Determine SUSE modules to register
+  ansible.builtin.set_fact:
+    suseconnect_subscriptions: >-
+      {{
+        []
+        if (ansible_facts['distribution_major_version'] | int >= 16)
+        else
+        (
+          [
+            {'name': 'sle-module-basesystem', 'state': 'enabled'},
+            {'name': 'sle-module-python3', 'state': 'enabled'}
+          ]
+          + ([{'name': 'sle-module-legacy', 'state': 'enabled'}] if ansible_facts['distribution_version'] == '15.6' else [])
+        )
+      }}
+  when: enable_autoregister | bool
+
+- name: Register with SCC and activate modules
+  ansible.builtin.include_role:
+    name: suseconnect
+  when:
+    - enable_autoregister | bool
+    - suseconnect_subscriptions | default([]) | length > 0
+
 - name: Install RabbitMQ
   community.general.zypper:
     name: rabbitmq-server

--- a/roles/rabbitmq/tasks/main.yml
+++ b/roles/rabbitmq/tasks/main.yml
@@ -5,7 +5,7 @@
 ---
 - name: Determine SUSE modules to register
   ansible.builtin.set_fact:
-    suseconnect_subscriptions: >-
+    rabbitmq_suseconnect_subscriptions: >-
       {{
         []
         if (ansible_facts['distribution_major_version'] | int >= 16)
@@ -23,9 +23,11 @@
 - name: Register with SCC and activate modules
   ansible.builtin.include_role:
     name: suseconnect
+  vars:
+    suseconnect_subscriptions: "{{ rabbitmq_suseconnect_subscriptions }}"
   when:
     - enable_autoregister | bool
-    - suseconnect_subscriptions | default([]) | length > 0
+    - rabbitmq_suseconnect_subscriptions | default([]) | length > 0
 
 - name: Install RabbitMQ
   community.general.zypper:

--- a/roles/rproxy/tasks/main.yml
+++ b/roles/rproxy/tasks/main.yml
@@ -5,7 +5,7 @@
 ---
 - name: Determine SUSE modules to register
   ansible.builtin.set_fact:
-    suseconnect_subscriptions: >-
+    rproxy_suseconnect_subscriptions: >-
       {{
         []
         if (ansible_facts['distribution_major_version'] | int >= 16)
@@ -25,10 +25,12 @@
 - name: Register with SCC and activate modules
   ansible.builtin.include_role:
     name: suseconnect
+  vars:
+    suseconnect_subscriptions: "{{ rproxy_suseconnect_subscriptions }}"
   when:
     - rproxy_install | bool
     - enable_autoregister | bool
-    - suseconnect_subscriptions | default([]) | length > 0
+    - rproxy_suseconnect_subscriptions | default([]) | length > 0
 
 - name: Install nginx
   when: rproxy_install | bool

--- a/roles/rproxy/tasks/main.yml
+++ b/roles/rproxy/tasks/main.yml
@@ -3,6 +3,33 @@
 
 # code: language=ansible
 ---
+- name: Determine SUSE modules to register
+  ansible.builtin.set_fact:
+    suseconnect_subscriptions: >-
+      {{
+        []
+        if (ansible_facts['distribution_major_version'] | int >= 16)
+        else
+        (
+          [
+            {'name': 'sle-module-basesystem', 'state': 'enabled'},
+            {'name': 'sle-module-python3', 'state': 'enabled'}
+          ]
+          + ([{'name': 'sle-module-legacy', 'state': 'enabled'}] if ansible_facts['distribution_version'] == '15.6' else [])
+        )
+      }}
+  when:
+    - rproxy_install | bool
+    - enable_autoregister | bool
+
+- name: Register with SCC and activate modules
+  ansible.builtin.include_role:
+    name: suseconnect
+  when:
+    - rproxy_install | bool
+    - enable_autoregister | bool
+    - suseconnect_subscriptions | default([]) | length > 0
+
 - name: Install nginx
   when: rproxy_install | bool
   community.general.zypper:

--- a/roles/supportutils/tasks/main.yml
+++ b/roles/supportutils/tasks/main.yml
@@ -5,7 +5,7 @@
 ---
 - name: Determine SUSE modules to register
   ansible.builtin.set_fact:
-    suseconnect_subscriptions: >-
+    supportutils_suseconnect_subscriptions: >-
       {{
         []
         if (ansible_facts['distribution_major_version'] | int >= 16)
@@ -25,10 +25,12 @@
 - name: Register with SCC and activate modules
   ansible.builtin.include_role:
     name: suseconnect
+  vars:
+    suseconnect_subscriptions: "{{ supportutils_suseconnect_subscriptions }}"
   when:
     - supportutils_enabled | bool
     - enable_autoregister | bool
-    - suseconnect_subscriptions | default([]) | length > 0
+    - supportutils_suseconnect_subscriptions | default([]) | length > 0
 
 - name: Install Trento support tooling
   community.general.zypper:

--- a/roles/supportutils/tasks/main.yml
+++ b/roles/supportutils/tasks/main.yml
@@ -3,6 +3,33 @@
 
 # code: language=ansible
 ---
+- name: Determine SUSE modules to register
+  ansible.builtin.set_fact:
+    suseconnect_subscriptions: >-
+      {{
+        []
+        if (ansible_facts['distribution_major_version'] | int >= 16)
+        else
+        (
+          [
+            {'name': 'sle-module-basesystem', 'state': 'enabled'},
+            {'name': 'sle-module-python3', 'state': 'enabled'}
+          ]
+          + ([{'name': 'sle-module-legacy', 'state': 'enabled'}] if ansible_facts['distribution_version'] == '15.6' else [])
+        )
+      }}
+  when:
+    - supportutils_enabled | bool
+    - enable_autoregister | bool
+
+- name: Register with SCC and activate modules
+  ansible.builtin.include_role:
+    name: suseconnect
+  when:
+    - supportutils_enabled | bool
+    - enable_autoregister | bool
+    - suseconnect_subscriptions | default([]) | length > 0
+
 - name: Install Trento support tooling
   community.general.zypper:
     name:

--- a/roles/wanda/tasks/docker.yml
+++ b/roles/wanda/tasks/docker.yml
@@ -4,7 +4,7 @@
 ---
 - name: Determine SUSE modules to register
   ansible.builtin.set_fact:
-    suseconnect_subscriptions: >-
+    wanda_suseconnect_subscriptions: >-
       {{
         []
         if (ansible_facts['distribution_major_version'] | int >= 16)
@@ -22,9 +22,11 @@
 - name: Register with SCC and activate modules
   ansible.builtin.include_role:
     name: suseconnect
+  vars:
+    suseconnect_subscriptions: "{{ wanda_suseconnect_subscriptions }}"
   when:
     - enable_autoregister | bool
-    - suseconnect_subscriptions | default([]) | length > 0
+    - wanda_suseconnect_subscriptions | default([]) | length > 0
 
 - name: Include Docker installation variables
   ansible.builtin.include_vars: "../vars/docker.yml"

--- a/roles/wanda/tasks/docker.yml
+++ b/roles/wanda/tasks/docker.yml
@@ -2,6 +2,30 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
+- name: Determine SUSE modules to register
+  ansible.builtin.set_fact:
+    suseconnect_subscriptions: >-
+      {{
+        []
+        if (ansible_facts['distribution_major_version'] | int >= 16)
+        else
+        (
+          [
+            {'name': 'sle-module-basesystem', 'state': 'enabled'},
+            {'name': 'sle-module-python3', 'state': 'enabled'}
+          ]
+          + ([{'name': 'sle-module-legacy', 'state': 'enabled'}] if ansible_facts['distribution_version'] == '15.6' else [])
+        )
+      }}
+  when: enable_autoregister | bool
+
+- name: Register with SCC and activate modules
+  ansible.builtin.include_role:
+    name: suseconnect
+  when:
+    - enable_autoregister | bool
+    - suseconnect_subscriptions | default([]) | length > 0
+
 - name: Include Docker installation variables
   ansible.builtin.include_vars: "../vars/docker.yml"
 

--- a/roles/wanda/tasks/rpm.yml
+++ b/roles/wanda/tasks/rpm.yml
@@ -2,6 +2,30 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
+- name: Determine SUSE modules to register
+  ansible.builtin.set_fact:
+    suseconnect_subscriptions: >-
+      {{
+        []
+        if (ansible_facts['distribution_major_version'] | int >= 16)
+        else
+        (
+          [
+            {'name': 'sle-module-basesystem', 'state': 'enabled'},
+            {'name': 'sle-module-python3', 'state': 'enabled'}
+          ]
+          + ([{'name': 'sle-module-legacy', 'state': 'enabled'}] if ansible_facts['distribution_version'] == '15.6' else [])
+        )
+      }}
+  when: enable_autoregister | bool
+
+- name: Register with SCC and activate modules
+  ansible.builtin.include_role:
+    name: suseconnect
+  when:
+    - enable_autoregister | bool
+    - suseconnect_subscriptions | default([]) | length > 0
+
 - name: Install Trento Wanda RPM packages
   community.general.zypper:
     name:

--- a/roles/wanda/tasks/rpm.yml
+++ b/roles/wanda/tasks/rpm.yml
@@ -4,7 +4,7 @@
 ---
 - name: Determine SUSE modules to register
   ansible.builtin.set_fact:
-    suseconnect_subscriptions: >-
+    wanda_suseconnect_subscriptions: >-
       {{
         []
         if (ansible_facts['distribution_major_version'] | int >= 16)
@@ -22,9 +22,11 @@
 - name: Register with SCC and activate modules
   ansible.builtin.include_role:
     name: suseconnect
+  vars:
+    suseconnect_subscriptions: "{{ wanda_suseconnect_subscriptions }}"
   when:
     - enable_autoregister | bool
-    - suseconnect_subscriptions | default([]) | length > 0
+    - wanda_suseconnect_subscriptions | default([]) | length > 0
 
 - name: Install Trento Wanda RPM packages
   community.general.zypper:

--- a/roles/web/tasks/docker.yml
+++ b/roles/web/tasks/docker.yml
@@ -3,6 +3,30 @@
 
 # code: language=ansible
 ---
+- name: Determine SUSE modules to register
+  ansible.builtin.set_fact:
+    suseconnect_subscriptions: >-
+      {{
+        []
+        if (ansible_facts['distribution_major_version'] | int >= 16)
+        else
+        (
+          [
+            {'name': 'sle-module-basesystem', 'state': 'enabled'},
+            {'name': 'sle-module-python3', 'state': 'enabled'}
+          ]
+          + ([{'name': 'sle-module-legacy', 'state': 'enabled'}] if ansible_facts['distribution_version'] == '15.6' else [])
+        )
+      }}
+  when: enable_autoregister | bool
+
+- name: Register with SCC and activate modules
+  ansible.builtin.include_role:
+    name: suseconnect
+  when:
+    - enable_autoregister | bool
+    - suseconnect_subscriptions | default([]) | length > 0
+
 - name: Include Docker installation variables
   ansible.builtin.include_vars: "../vars/docker.yml"
 

--- a/roles/web/tasks/docker.yml
+++ b/roles/web/tasks/docker.yml
@@ -5,7 +5,7 @@
 ---
 - name: Determine SUSE modules to register
   ansible.builtin.set_fact:
-    suseconnect_subscriptions: >-
+    web_suseconnect_subscriptions: >-
       {{
         []
         if (ansible_facts['distribution_major_version'] | int >= 16)
@@ -23,9 +23,11 @@
 - name: Register with SCC and activate modules
   ansible.builtin.include_role:
     name: suseconnect
+  vars:
+    suseconnect_subscriptions: "{{ web_suseconnect_subscriptions }}"
   when:
     - enable_autoregister | bool
-    - suseconnect_subscriptions | default([]) | length > 0
+    - web_suseconnect_subscriptions | default([]) | length > 0
 
 - name: Include Docker installation variables
   ansible.builtin.include_vars: "../vars/docker.yml"

--- a/roles/web/tasks/rpm.yml
+++ b/roles/web/tasks/rpm.yml
@@ -5,7 +5,7 @@
 ---
 - name: Determine SUSE modules to register
   ansible.builtin.set_fact:
-    suseconnect_subscriptions: >-
+    web_suseconnect_subscriptions: >-
       {{
         []
         if (ansible_facts['distribution_major_version'] | int >= 16)
@@ -23,9 +23,11 @@
 - name: Register with SCC and activate modules
   ansible.builtin.include_role:
     name: suseconnect
+  vars:
+    suseconnect_subscriptions: "{{ web_suseconnect_subscriptions }}"
   when:
     - enable_autoregister | bool
-    - suseconnect_subscriptions | default([]) | length > 0
+    - web_suseconnect_subscriptions | default([]) | length > 0
 
 - name: Install Trento Web RPM packages
   community.general.zypper:

--- a/roles/web/tasks/rpm.yml
+++ b/roles/web/tasks/rpm.yml
@@ -3,6 +3,30 @@
 
 # code: language=ansible
 ---
+- name: Determine SUSE modules to register
+  ansible.builtin.set_fact:
+    suseconnect_subscriptions: >-
+      {{
+        []
+        if (ansible_facts['distribution_major_version'] | int >= 16)
+        else
+        (
+          [
+            {'name': 'sle-module-basesystem', 'state': 'enabled'},
+            {'name': 'sle-module-python3', 'state': 'enabled'}
+          ]
+          + ([{'name': 'sle-module-legacy', 'state': 'enabled'}] if ansible_facts['distribution_version'] == '15.6' else [])
+        )
+      }}
+  when: enable_autoregister | bool
+
+- name: Register with SCC and activate modules
+  ansible.builtin.include_role:
+    name: suseconnect
+  when:
+    - enable_autoregister | bool
+    - suseconnect_subscriptions | default([]) | length > 0
+
 - name: Install Trento Web RPM packages
   community.general.zypper:
     name:


### PR DESCRIPTION
### Description

This pull request introduces automatic SUSE module registration for supported roles, making it easier to ensure all required repositories are enabled before package installation. It also improves error handling and updates documentation and dependency management for better user experience and reliability.

**Automatic SUSE module registration and improved error handling:**

* Added logic to all relevant roles (e.g., `agent`, `firewall`, `postgres`, `prometheus`, `rabbitmq`, `rproxy`, `supportutils`, `wanda`, `web`) to automatically determine and register required SUSE modules via the `suseconnect` role when `enable_autoregister` is set to `true`. This avoids manual registration steps and ensures all modules are present for package installation. 
* Improved error handling for package installation in `agent` and `prometheus` roles: if installation fails due to missing Package Hub, a clear error message is shown with guidance to register the required module
* Introduced the `enable_autoregister` variable (default: `false`) in `group_vars/all.yml` and documented it in the `README.adoc`, allowing users to control whether module registration is automatic. 
* Added the `suseconnect` role as a dependency in `requirements.yml` and updated the `k3s-ansible` collection version in `devbox/ansible/requirements.yml`. 

Fixes #TRNT-4463

### How was this tested?

CI + limited IRL test

### Documentation changes

Yes

### Additional information

Example output

#### More friendly error message

```console
TASK [prometheus : Install package using zypper module] **********************************************************************************************************************************************************
[ERROR]: Task failed: Module failed: No provider of '+golang-github-prometheus-prometheus' found.
Origin: /mnt/c/repos/trento-ansible/roles/prometheus/tasks/main.yml:46:7

....

TASK [prometheus : Fail with Package Hub guidance] ***************************************************************************************************************************************************************
[ERROR]: Task failed: Action failed: Failed to install golang-github-prometheus-prometheus. Register SUSE Package Hub first: SUSEConnect -p PackageHub/16.1/x86_64
Origin: /mnt/c/repos/trento-ansible/roles/prometheus/tasks/main.yml:51:7

...

fatal: [10.144.73.55]: FAILED! => {"changed": false, "msg": "Failed to install golang-github-prometheus-prometheus. Register SUSE Package Hub first: SUSEConnect -p PackageHub/16.1/x86_64"}
```


#### Autoregistration enabled

```console
TASK [suseconnect : Manage modules and extensions] ***************************************************************************************************************************************************************
changed: [10.144.73.55] => (item=PackageHub)

...

TASK [prometheus : Install package using zypper module] **********************************************************************************************************************************************************
changed: [10.144.73.55]
```