### PR TITLE
Check for colliding ports before each role

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -431,7 +431,9 @@ per-role basis if appropriate.
   is ignored when `trento_prometheus_host_group` is non-empty string. |
   localhost
 
-| trento_prometheus_port | Canonical port for playbook-managed Prometheus. | 9090
+| trento_prometheus_port | Canonical port for playbook-managed Prometheus.
+  Note that port 9090 is also Cockpit's default port on SLES; if Cockpit is
+  enabled on the target host, override this variable to avoid a conflict. | 9090
 
 | trento_prometheus_auth | Authentication method for the Prometheus endpoint.
   Must be "basic" or "none". Shared default for both `rproxy_prometheus_auth`

--- a/roles/port_check/README.adoc
+++ b/roles/port_check/README.adoc
@@ -1,0 +1,62 @@
+= Port Check Ansible Role
+
+Helper role that allows us to concentrate our common "is this port
+free before we bind it" handling into a single re-usable component.
+This role is not intended to be used directly by end-users.
+
+Our common handling includes:
+. Checking whether the target systemd service is already running.
+.. If it is, the port is assumed to be legitimately owned by it
+already (eg. a re-run of the playbook) and no further check is done.
+. Otherwise, checking whether any process is already listening on
+the given port.
+.. If one is, the play fails with a message naming the offending
+process/pid and a hint on how to resolve the conflict, instead of
+letting package/service tasks fail later with a less helpful error.
+
+== Requirements
+
+This role uses `community.general.listen_ports_facts` and
+`ansible.builtin.service_facts`, so it depends on their
+dependencies.
+
+== Role Variables
+
+[width="100%",cols="16%,57%,27%",options="header",]
+|===
+| Name | Description | Default
+| port_check_port | TCP port that is about to be bound. | <undefined/mandatory>
+| port_check_service | systemd unit name (without the `.service`
+  suffix) that is expected to own the port once started. | <undefined/mandatory>
+| port_check_hint | Extra text appended to the failure message,
+  eg. which variable to change to pick a different port. | ""
+|===
+
+== Dependencies
+
+This role does not have any dependencies on other roles, nor exports
+any variables.
+
+== Example Playbook
+
+[source, yaml]
+----
+- hosts: servers
+  tasks:
+    - name: Verify Prometheus port availability
+      ansible.builtin.include_role:
+        name: suse.trento.port_check
+      vars:
+        port_check_port: "{{ trento_prometheus_port }}"
+        port_check_service: prometheus
+        port_check_hint: "Set prometheus_port to a free port and re-run the playbook."
+----
+
+== License
+
+Apache License, Version 2.0
+
+== Author Information
+
+Developed and maintained by trento-developers@suse.com
+Code repository is hosted on https://github.com/trento-project/ansible

--- a/roles/port_check/defaults/main.yml
+++ b/roles/port_check/defaults/main.yml
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
+---
+port_check_port: "{{ undef(hint='port_check_port is mandatory') }}"
+port_check_service: "{{ undef(hint='port_check_service (systemd unit name, without the .service suffix) is mandatory') }}"
+port_check_hint: ""

--- a/roles/port_check/meta/main.yml
+++ b/roles/port_check/meta/main.yml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
+galaxy_info:
+  author: "trento-developers@suse.com"
+  description: Fail gracefully when a port required by a Trento component is already occupied
+  company: SUSE
+  license: Apache-2.0
+  min_ansible_version: "2.1"
+  galaxy_tags: []
+
+dependencies: []

--- a/roles/port_check/tasks/main.yml
+++ b/roles/port_check/tasks/main.yml
@@ -6,7 +6,7 @@
 - name: Gather systemd service facts
   ansible.builtin.service_facts:
 
-- name: "Check whether {{ port_check_service }} already owns the port"
+- name: "Check whether the target service already owns port {{ port_check_port }}"
   ansible.builtin.set_fact:
     __port_check_service_running: >-
       {{ (ansible_facts.services[port_check_service ~ '.service'] | default({'state': 'unknown'})).state == 'running' }}
@@ -14,7 +14,7 @@
 # When the service already owns the port (eg. a re-run of the
 # playbook) there is nothing to check: the port is expected to be
 # occupied by our own service.
-- name: "Verify port {{ port_check_port }} is free for {{ port_check_service }}"
+- name: "Verify availability of port {{ port_check_port }}"
   when: not (__port_check_service_running | bool)
   block:
     - name: Gather listening ports facts
@@ -24,7 +24,7 @@
       ansible.builtin.set_fact:
         __port_check_conflicts: "{{ ansible_facts.tcp_listen | selectattr('port', 'equalto', port_check_port | int) | list }}"
 
-    - name: "Fail gracefully when port {{ port_check_port }} is occupied"
+    - name: "Fail gracefully for occupied port {{ port_check_port }}"
       ansible.builtin.fail:
         msg: >-
           Port {{ port_check_port }} is required by {{ port_check_service }} on

--- a/roles/port_check/tasks/main.yml
+++ b/roles/port_check/tasks/main.yml
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
+# code: language=ansible
+---
+- name: Gather systemd service facts
+  ansible.builtin.service_facts:
+
+- name: "Check whether {{ port_check_service }} already owns the port"
+  ansible.builtin.set_fact:
+    __port_check_service_running: >-
+      {{ (ansible_facts.services[port_check_service ~ '.service'] | default({'state': 'unknown'})).state == 'running' }}
+
+# When the service already owns the port (eg. a re-run of the
+# playbook) there is nothing to check: the port is expected to be
+# occupied by our own service.
+- name: "Verify port {{ port_check_port }} is free for {{ port_check_service }}"
+  when: not (__port_check_service_running | bool)
+  block:
+    - name: Gather listening ports facts
+      community.general.listen_ports_facts:
+
+    - name: "Identify processes already bound to port {{ port_check_port }}"
+      ansible.builtin.set_fact:
+        __port_check_conflicts: "{{ ansible_facts.tcp_listen | selectattr('port', 'equalto', port_check_port | int) | list }}"
+
+    - name: "Fail gracefully when port {{ port_check_port }} is occupied"
+      ansible.builtin.fail:
+        msg: >-
+          Port {{ port_check_port }} is required by {{ port_check_service }} on
+          {{ inventory_hostname }}, but it is already in use by
+          {{ __port_check_conflicts | map(attribute='name') | join(', ') }}
+          (pid {{ __port_check_conflicts | map(attribute='pid') | join(', ') }}).
+          {{ port_check_hint }}
+      when: __port_check_conflicts | length > 0

--- a/roles/postgres/tasks/main.yml
+++ b/roles/postgres/tasks/main.yml
@@ -3,6 +3,18 @@
 
 # code: language=ansible
 ---
+- name: Verify Postgres port availability
+  ansible.builtin.include_role:
+    name: port_check
+  vars:
+    # 5432 is PostgreSQL's package default; this role does not expose
+    # a variable to change it.
+    port_check_port: 5432
+    port_check_service: postgresql
+    port_check_hint: >-
+      Free port 5432 on this host, or set provision_postgres to false and point
+      trento_postgres_host at an existing external PostgreSQL instance.
+
 - name: Install postgresql
   when: postgres_install | bool
   community.general.zypper:

--- a/roles/prometheus/tasks/main.yml
+++ b/roles/prometheus/tasks/main.yml
@@ -3,6 +3,16 @@
 
 # code: language=ansible
 ---
+- name: Verify Prometheus port availability
+  ansible.builtin.include_role:
+    name: port_check
+  vars:
+    port_check_port: "{{ trento_prometheus_port }}"
+    port_check_service: prometheus
+    port_check_hint: >-
+      Set prometheus_port (or trento_prometheus_port) to a free port and re-run the
+      playbook. Note that port 9090 is also Cockpit's default port on SLES.
+
 - name: Ensure prometheus group is present
   ansible.builtin.group:
     name: prometheus

--- a/roles/rabbitmq/tasks/main.yml
+++ b/roles/rabbitmq/tasks/main.yml
@@ -3,6 +3,18 @@
 
 # code: language=ansible
 ---
+- name: Verify RabbitMQ port availability
+  ansible.builtin.include_role:
+    name: port_check
+  vars:
+    # 5672 is RabbitMQ's package default AMQP port; this role does not
+    # expose a variable to change it.
+    port_check_port: 5672
+    port_check_service: rabbitmq-server
+    port_check_hint: >-
+      Free port 5672 on this host, or set provision_rabbitmq to false and point
+      trento_rabbitmq_host at an existing external RabbitMQ instance.
+
 - name: Install RabbitMQ
   community.general.zypper:
     name: rabbitmq-server

--- a/roles/rproxy/tasks/main.yml
+++ b/roles/rproxy/tasks/main.yml
@@ -3,6 +3,19 @@
 
 # code: language=ansible
 ---
+- name: Verify reverse proxy port availability
+  ansible.builtin.include_role:
+    name: port_check
+  vars:
+    port_check_port: "{{ item }}"
+    port_check_service: "{{ rproxy_os_service }}"
+    port_check_hint: >-
+      Set nginx_vhost_http_listen_port / nginx_vhost_https_listen_port to free ports
+      and re-run the playbook.
+  loop:
+    - "{{ rproxy_vhost_http_listen_port }}"
+    - "{{ rproxy_vhost_https_listen_port }}"
+
 - name: Install nginx
   when: rproxy_install | bool
   community.general.zypper:


### PR DESCRIPTION
### Description

This pull request introduces a new reusable Ansible role, `port_check`, to standardize and improve the handling of port conflicts across several service roles. The `port_check` role checks if a required port is already in use before attempting to bind services, allowing for clearer error messages and easier troubleshooting. The role is integrated into the `prometheus`, `postgres`, `rabbitmq`, and `rproxy` roles, and comprehensive documentation and defaults are provided.

**New port conflict detection role:**

* Added the `port_check` role, which checks if a port is available or already owned by the intended systemd service, and fails gracefully with a helpful message if a conflict is detected.
* Integrated the `port_check` role at the start of the `prometheus`, `postgres`, `rabbitmq`, and `rproxy` roles to ensure required ports are free before proceeding with installation or configuration.
* Updated the main `README.adoc` to clarify that Prometheus's default port (9090) may conflict with Cockpit on SLES, and to recommend overriding the port in that case.

Fixes #TNRT-4636

### How was this tested?

IRL

### Documentation changes

Yes

### Additional information

Example:

```console
TASK [port_check : Fail gracefully when port 9090 is occupied] ***************************************************************************************************************************************************
...

fatal: [10.144.73.55]: FAILED! => {"changed": false, "msg": "Port 9090 is required by prometheus on 10.144.73.55, but it is already in use by systemd (pid 1). Set prometheus_port (or trento_prometheus_port) to a free port and re-run the playbook. Note that port 9090 is also Cockpit's default port on SLES."}

...
```

CI is gonna fail; this is just for checking. If we need to fix it, then something like #134  is needed
