### PR TITLE
Use "trento-checks" img

### DIFF
--- a/roles/wanda/vars/docker.yml
+++ b/roles/wanda/vars/docker.yml
@@ -8,7 +8,7 @@ wanda_container_image: ghcr.io/trento-project/trento-wanda:rolling
 wanda_container_name: trento_wanda
 wanda_force_recreate_wanda_container: false
 wanda_remove_wanda_container_image: true
-wanda_checks_container_image: ghcr.io/trento-project/checks:rolling
+wanda_checks_container_image: ghcr.io/trento-project/trento-checks:rolling
 wanda_checks_container_name: trento_checks
 wanda_force_recreate_checks_container: false
 wanda_remove_checks_container_image: true


### PR DESCRIPTION
### Description

I've noticed we are using the old pkg name. In order to keep consistency, this PR aligns the value to the one used in the Helm Chart: https://github.com/trento-project/helm-charts/blob/main/charts/trento-server/values.yaml#L59

### How was this tested?

Ci

### Documentation changes

No

### Additional information

- [ ] https://github.com/trento-project/web/pull/4583
- [ ] https://github.com/trento-project/ansible/pull/133