### PR TITLE
Use fallback Prometheus port in SLES 16

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -431,7 +431,10 @@ per-role basis if appropriate.
   is ignored when `trento_prometheus_host_group` is non-empty string. |
   localhost
 
-| trento_prometheus_port | Canonical port for playbook-managed Prometheus. | 9090
+| trento_prometheus_port | Canonical port for playbook-managed Prometheus.
+  Defaults to 9191 on SLES 16 since Cockpit already occupies 9090 there;
+  override this variable directly if you need a different value. | 9090
+  (9191 on SLES 16)
 
 | trento_prometheus_auth | Authentication method for the Prometheus endpoint.
   Must be "basic" or "none". Shared default for both `rproxy_prometheus_auth`
@@ -841,7 +844,7 @@ More detailed info about usage and defaults available link:https://github.com/tr
 | Name | Description | Default
 
 | prometheus_port | Deprecated alias for `trento_prometheus_port`.
-  Keep unset for new deployments. | 9090
+  Keep unset for new deployments. | 9090 (9191 on SLES 16)
 
 | prometheus_web_url | Base URL of Trento Web application where
   Prometheus scrapes for metrics | http://<`trento_server_name`>

--- a/roles/trento/defaults/main.yml
+++ b/roles/trento/defaults/main.yml
@@ -40,7 +40,7 @@ trento_rabbitmq_password: "{{ undef(hint='Password for RabbitMQ trento user is m
 trento_rabbitmq_vhost: trento
 trento_prometheus_host_group: ""
 trento_prometheus_host: localhost
-trento_prometheus_port: "{{ prometheus_port | default(9090) }}" # `prometheus_port` for backwards-compatibility
+trento_prometheus_port: "{{ prometheus_port | default((ansible_distribution_major_version == '16') | ternary(9191, 9090)) }}" # `prometheus_port` for backwards-compatibility; SLES 16 defaults to 9191 since Cockpit already occupies 9090 there
 trento_prometheus_auth: ""
 trento_prometheus_auth_username: ""
 trento_prometheus_auth_password: ""


### PR DESCRIPTION
### Description

This pull request updates the default port configuration for Prometheus to better support SLES 16 environments, where port 9090 is already used by Cockpit. It also improves the documentation to clarify these changes and the related default values.

**Prometheus port default changes:**

* Updated the default value of `trento_prometheus_port` in `roles/trento/defaults/main.yml` to use port 9191 on SLES 16, while keeping 9090 as the default elsewhere. This prevents port conflicts with Cockpit on SLES 16.
* Updated the documentation in `README.adoc` to explain the new default behavior for `trento_prometheus_port`, specifying that it defaults to 9191 on SLES 16 and can be overridden if needed.
* Updated the deprecated `prometheus_port` variable documentation to reflect the new SLES 16 default (9191), improving clarity for users migrating or deploying on SLES 16.

Fixes #TNRT-4636

### How was this tested?

IRL

### Documentation changes

Yes

### Additional information

Related to #132 
